### PR TITLE
Allows to override domain translation when including in template

### DIFF
--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -71,14 +71,17 @@ class SonataCoreExtension extends Extension
     {
         $types = array(
             'success' => array_merge($config['flashmessage']['success'], array(
+                'success' => array('domain' => 'SonataCoreBundle'),
                 'sonata_flash_success' => array('domain' => 'SonataAdminBundle'),
                 'sonata_user_success'  => array('domain' => 'SonataUserBundle'),
                 'fos_user_success'     => array('domain' => 'FOSUserBundle'),
             )),
             'warning' => array_merge($config['flashmessage']['warning'], array(
+                'warning' => array('domain' => 'SonataCoreBundle'),
                 'sonata_flash_info' => array('domain' => 'SonataAdminBundle'),
             )),
             'error' => array_merge($config['flashmessage']['error'], array(
+                'error' => array('domain' => 'SonataCoreBundle'),
                 'sonata_flash_error' => array('domain' => 'SonataAdminBundle'),
                 'sonata_user_error'  => array('domain' => 'SonataUserBundle'),
             )),

--- a/FlashMessage/FlashManager.php
+++ b/FlashMessage/FlashManager.php
@@ -83,13 +83,14 @@ class FlashManager
     /**
      * Returns flash bag messages for correct type after renaming with Sonata core type
      *
-     * @param string $type
+     * @param string $type   Type of flash message
+     * @param string $domain Translation domain to use
      *
      * @return array
      */
-    public function get($type)
+    public function get($type, $domain = null)
     {
-        $this->handle();
+        $this->handle($domain);
 
         return $this->getSession()->getFlashBag()->get($type);
     }
@@ -97,13 +98,16 @@ class FlashManager
     /**
      * Handles flash bag types renaming
      *
+     * @param string $domain
+     *
      * @return void
      */
-    protected function handle()
+    protected function handle($domain = null)
     {
         foreach ($this->getTypes() as $type => $values) {
             foreach ($values as $value => $options) {
-                $this->rename($type, $value, $options['domain']);
+                $domainType = $domain ?: $options['domain'];
+                $this->rename($type, $value, $domainType);
             }
         }
     }

--- a/Resources/doc/reference/flash_messages.rst
+++ b/Resources/doc/reference/flash_messages.rst
@@ -39,3 +39,9 @@ To use this feature in your templates, simply include the following template (wi
 .. code-block:: twig
 
     {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
+
+Please note that if necessary, you can also specify a translation domain to override configuration here:
+
+.. code-block:: twig
+
+    {% include 'SonataCoreBundle:FlashMessage:render.html.twig' with {domain: 'MyCustomBundle'} %}

--- a/Resources/views/FlashMessage/render.html.twig
+++ b/Resources/views/FlashMessage/render.html.twig
@@ -9,7 +9,8 @@ file that was distributed with this source code.
 
 #}
 {% for type in ['success', 'error', 'warning'] %}
-    {% for message in sonata_flashmessages_get(type) %}
+    {% set domain = domain is defined ? domain : null %}
+    {% for message in sonata_flashmessages_get(type, domain) %}
         <div class="alert alert-{{ type }}">
             {{ message|raw }}
         </div>

--- a/Tests/FlashMessage/FlashManagerTest.php
+++ b/Tests/FlashMessage/FlashManagerTest.php
@@ -7,9 +7,10 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Translator;
 
 use Sonata\CoreBundle\FlashMessage\FlashManager;
-use Symfony\Component\Translation\Translator;
 
 /**
  * Class FlashManagerTest
@@ -155,6 +156,38 @@ class FlashManagerTest extends \PHPUnit_Framework_TestCase
 
         foreach ($nonRegisteredMessages as $message) {
             $this->assertEquals($message, 'hey, success dude!');
+        }
+    }
+
+    /**
+     * Test the flash manager get() method with a specified domain
+     */
+    public function testFlashMessageWithCustomDomain()
+    {
+        // Given
+        $translator = $this->flashManager->getTranslator();
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', array(
+            'my_bundle_success_message' => 'My bundle success message!'
+        ), 'en', 'MyCustomDomain');
+
+        // When
+        $this->session->getFlashBag()->set('my_bundle_success', 'my_bundle_success_message');
+        $messages = $this->flashManager->get('success', 'MyCustomDomain');
+
+        $this->session->getFlashBag()->set('my_bundle_success', 'my_bundle_success_message');
+        $messagesWithoutDomain = $this->flashManager->get('success');
+
+        // Then
+        $this->assertCount(1, $messages);
+        $this->assertCount(1, $messagesWithoutDomain);
+
+        foreach ($messages as $message) {
+            $this->assertEquals($message, 'My bundle success message!');
+        }
+
+        foreach ($messagesWithoutDomain as $message) {
+            $this->assertEquals($message, 'my_bundle_success_message');
         }
     }
 

--- a/Twig/Extension/FlashMessageExtension.php
+++ b/Twig/Extension/FlashMessageExtension.php
@@ -50,13 +50,14 @@ class FlashMessageExtension extends \Twig_Extension
     /**
      * Returns flash messages handled by Sonata core flash manager
      *
-     * @param string $type
+     * @param string $type   Type of flash message
+     * @param string $domain Translation domain to use
      *
      * @return string
      */
-    public function getFlashMessages($type)
+    public function getFlashMessages($type, $domain = null)
     {
-        return $this->flashManager->get($type);
+        return $this->flashManager->get($type, $domain);
     }
 
     /**


### PR DESCRIPTION
I've keeped the domain parameter when including because in some cases, we need to override the translation specified in configuration.

For example, in `sonata-project/ecommerce`:

We have the following code in view `SonataCustomerBundle:Addresses:list.html.twig`:

``` php
{% for success in app.session.flashBag.get('success') %}
    <div class="alert alert-success">
        <p>{{ success|trans({}, 'SonataCustomerBundle') }}</p>
    </div>
{% endfor %}
```

Here, a flash message is set with key `success` and we have to specify that in this template that the message must be translated from `SonataCustomerBundle`.

So we have to do:

``` php
{% include 'SonataCoreBundle:FlashMessage:render.html.twig' with {domain: 'SonataCustomerBundle'} %}
```
