### PR TITLE
Move Twig Text extension to core bundle

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -5,6 +5,10 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="sonata.core.twig.extension.text" class="Twig_Extensions_Extension_Text">
+            <tag name="twig.extension"/>
+        </service>
+
         <service id="sonata.core.twig.status_extension" class="Sonata\CoreBundle\Twig\Extension\StatusExtension">
             <tag name="twig.extension" />
         </service>


### PR DESCRIPTION
As the sandbox now uses new kernel notions, `SonataAdminBundle` is not loaded in `FrontKernel` and this Twig Text extension was loaded in `SonataAdminBundle`.
Problem is that some front-end bundles (like `ecommerce` bundles and `SonataNewsBundle`) uses `truncate()` method that needs Twig Text extension to be loaded.

So I've moved Twig Text extension to `SonataCoreBundle` as both front & admin bundles will need it (and this need is shared between multiple bundles).

Following PR removes the reference from `SonataAdminBundle`: https://github.com/sonata-project/SonataAdminBundle/pull/1942
