### PR TITLE
Update sonata_template_box to allow translations

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -17,6 +17,7 @@
             <tag name="twig.extension" />
 
             <argument>%kernel.debug%</argument>
+            <argument type="service" id="translator" />
             <argument type="service" id="sonata.core.model.adapter.chain" />
         </service>
     </services>

--- a/Resources/translations/SonataCoreBundle.bg.xliff
+++ b/Resources/translations/SonataCoreBundle.bg.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>не</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.ca.xliff
+++ b/Resources/translations/SonataCoreBundle.ca.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.cs.xliff
+++ b/Resources/translations/SonataCoreBundle.cs.xliff
@@ -14,6 +14,10 @@
               <source>label_type_no</source>
               <target>ne</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.de.xliff
+++ b/Resources/translations/SonataCoreBundle.de.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>nein</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.en.xliff
+++ b/Resources/translations/SonataCoreBundle.en.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.es.xliff
+++ b/Resources/translations/SonataCoreBundle.es.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+                <source>sonata_core_template_box_file_found_in</source>
+                <target>This file can be found in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.fr.xliff
+++ b/Resources/translations/SonataCoreBundle.fr.xliff
@@ -14,6 +14,10 @@
                 <source>label_type_no</source>
                 <target>non</target>
             </trans-unit>
+            <trans-unit id="sonata_core_template_box_file_found_in">
+            <source>sonata_core_template_box_file_found_in</source>
+            <target>Ce fichier est localisé à l'emplacement</target>
+        </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Twig/Extension/TemplateExtensionTest.php
+++ b/Tests/Twig/Extension/TemplateExtensionTest.php
@@ -17,10 +17,12 @@ class TemplateExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testSlugify()
     {
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
         $adapter = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
         $adapter->expects($this->never())->method('getUrlsafeIdentifier');
 
-        $extension = new TemplateExtension(true, $adapter);
+        $extension = new TemplateExtension(true, $translator, $adapter);
 
         $this->assertEquals($extension->slugify('test'), 'test');
         $this->assertEquals($extension->slugify('S§!@@#$#$alut'), 's-alut');
@@ -32,10 +34,12 @@ class TemplateExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeUrl()
     {
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
         $adapter = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
         $adapter->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue("safe-parameter"));
 
-        $extension = new TemplateExtension(true, $adapter);
+        $extension = new TemplateExtension(true, $translator, $adapter);
 
         $this->assertEquals("safe-parameter", $extension->getUrlsafeIdentifier(new \stdClass()));
 

--- a/Tests/Twig/Node/TemplateBoxNodeTest.php
+++ b/Tests/Twig/Node/TemplateBoxNodeTest.php
@@ -12,12 +12,25 @@
 namespace Sonata\CoreBundle\Tests\Twig\TokenParser;
 
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Translator;
 
 class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
 {
     public function testConstructor()
     {
-        $body = new TemplateBoxNode(new \Twig_Node_Expression_Constant('This is the default message', 1), true, 1, 'sonata_template_box');
+        $translator = $this->getTranslator('en');
+
+        $body = new TemplateBoxNode(
+            new \Twig_Node_Expression_Constant('This is the default message', 1),
+            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
+            true,
+            $translator,
+            1,
+            'sonata_template_box'
+        );
+
         $this->assertEquals(1, $body->getLine());
     }
 
@@ -30,12 +43,35 @@ class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
         parent::testCompile($node, $source, $environment);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getTests()
     {
-        $node = new TemplateBoxNode(new \Twig_Node_Expression_Constant('This is the default message', 1), true, 1, 'sonata_template_box');
+        $translator = $this->getTranslator('en');
+
+        $nodeEn = new TemplateBoxNode(
+            new \Twig_Node_Expression_Constant('This is the default message', 1),
+            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
+            true,
+            $translator,
+            1,
+            'sonata_template_box'
+        );
+
+        $translator = $this->getTranslator('fr');
+
+        $nodeFr = new TemplateBoxNode(
+            new \Twig_Node_Expression_Constant('Ceci est le message par défaut', 1),
+            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
+            true,
+            $translator,
+            1,
+            'sonata_template_box'
+        );
 
         return array(
-            array($node, <<<EOF
+            array($nodeEn, <<<EOF
 // line 1
 echo "<div class='alert alert-default alert-info'>
     <strong>This is the default message</strong>
@@ -43,6 +79,34 @@ echo "<div class='alert alert-default alert-info'>
 </div>";
 EOF
             ),
+            array($nodeFr, <<<EOF
+// line 1
+echo "<div class='alert alert-default alert-info'>
+    <strong>Ceci est le message par défaut</strong>
+    <div>Ce fichier peut être trouvé à l'emplacement <code>{\$this->getTemplateName()}</code>.</div>
+</div>";
+EOF
+            ),
         );
+    }
+
+    /**
+     * Returns a Translator instance
+     *
+     * @param string $locale
+     *
+     * @return Translator
+     */
+    public function getTranslator($locale)
+    {
+        $translator = new Translator($locale, new MessageSelector());
+        $translator->addLoader('array', new ArrayLoader());
+
+        $translator->addResource('array', array('sonata_template_box_media_gallery_block' => 'This is the default message'), 'en', 'SonataCoreBundle');
+        $translator->addResource('array', array('sonata_template_box_media_gallery_block' => 'Ceci est le message par défaut'), 'fr', 'SonataCoreBundle');
+        $translator->addResource('array', array('sonata_core_template_box_file_found_in' => 'This file can be found in'), 'en', 'SonataCoreBundle');
+        $translator->addResource('array', array('sonata_core_template_box_file_found_in' => "Ce fichier peut être trouvé à l'emplacement"), 'fr', 'SonataCoreBundle');
+
+        return $translator;
     }
 }

--- a/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
+++ b/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
@@ -21,8 +21,10 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testCompile($enabled, $source, $expected)
     {
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
         $env = new \Twig_Environment(new \Twig_Loader_String(), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
-        $env->addTokenParser(new TemplateBoxTokenParser($enabled));
+        $env->addTokenParser(new TemplateBoxTokenParser($enabled, $translator));
         $stream = $env->tokenize($source);
         $parser = new \Twig_Parser($env);
 
@@ -31,13 +33,17 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function getTestsForRender()
     {
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
         return array(
             array(
                 true,
                 '{% sonata_template_box %}',
                 new TemplateBoxNode(
                     new \Twig_Node_Expression_Constant('Template information', 1),
+                    null,
                     true,
+                    $translator,
                     1,
                     'sonata_template_box'
                 )
@@ -47,7 +53,9 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
                 '{% sonata_template_box "This is the basket delivery address step page" %}',
                 new TemplateBoxNode(
                     new \Twig_Node_Expression_Constant('This is the basket delivery address step page', 1),
+                    null,
                     true,
+                    $translator,
                     1,
                     'sonata_template_box'
                 )
@@ -57,7 +65,9 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
                 '{% sonata_template_box "This is the basket delivery address step page" %}',
                 new TemplateBoxNode(
                     new \Twig_Node_Expression_Constant('This is the basket delivery address step page', 1),
+                    null,
                     false,
+                    $translator,
                     1,
                     'sonata_template_box'
                 )

--- a/Twig/Extension/TemplateExtension.php
+++ b/Twig/Extension/TemplateExtension.php
@@ -13,19 +13,36 @@ namespace Sonata\CoreBundle\Twig\Extension;
 
 use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateExtension extends \Twig_Extension
 {
+    /**
+     * @var bool
+     */
     protected $debug;
 
+    /**
+     * @var AdapterInterface
+     */
     protected $modelAdapter;
 
     /**
-     * @param bool $debug
+     * @var TranslatorInterface
      */
-    public function __construct($debug, AdapterInterface $modelAdapter)
+    protected $translator;
+
+    /**
+     * Constructor
+     *
+     * @param bool                $debug        Is Symfony debug enabled?
+     * @param TranslatorInterface $translator   Symfony Translator service
+     * @param AdapterInterface    $modelAdapter A Sonata model adapter
+     */
+    public function __construct($debug, TranslatorInterface $translator, AdapterInterface $modelAdapter)
     {
-        $this->debug = $debug;
+        $this->debug        = $debug;
+        $this->translator   = $translator;
         $this->modelAdapter = $modelAdapter;
     }
 
@@ -46,7 +63,7 @@ class TemplateExtension extends \Twig_Extension
     public function getTokenParsers()
     {
         return array(
-            new TemplateBoxTokenParser($this->debug),
+            new TemplateBoxTokenParser($this->debug, $this->translator),
         );
     }
 

--- a/Twig/Node/TemplateBoxNode.php
+++ b/Twig/Node/TemplateBoxNode.php
@@ -11,21 +11,36 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
+use Symfony\Component\Translation\TranslatorInterface;
+
 class TemplateBoxNode extends \Twig_Node
 {
+    /**
+     * @var int
+     */
     protected $enabled;
 
     /**
-     * @param \Twig_Node_Expression $message
-     * @param int                   $enabled
-     * @param null|string           $lineno
-     * @param null                  $tag
+     * @var TranslatorInterface
      */
-    public function __construct(\Twig_Node_Expression $message, $enabled, $lineno, $tag = null)
-    {
-        $this->enabled = $enabled;
+    protected $translator;
 
-        parent::__construct(array('message' => $message), array(), $lineno, $tag);
+    /**
+     * Constructor
+     *
+     * @param \Twig_Node_Expression $message           Node message to display
+     * @param \Twig_Node_Expression $translationBundle Node translation bundle to use for display
+     * @param int                   $enabled           Is Symfony debug enabled?
+     * @param TranslatorInterface   $translator        Symfony Translator service
+     * @param null|string           $lineno            Symfony template line number
+     * @param null                  $tag               Symfony tag name
+     */
+    public function __construct(\Twig_Node_Expression $message, \Twig_Node_Expression $translationBundle = null, $enabled, TranslatorInterface $translator, $lineno, $tag = null)
+    {
+        $this->enabled    = $enabled;
+        $this->translator = $translator;
+
+        parent::__construct(array('message' => $message, 'translationBundle' => $translationBundle), array(), $lineno, $tag);
     }
 
     /**
@@ -41,10 +56,18 @@ class TemplateBoxNode extends \Twig_Node
             return;
         }
 
+        $value = $this->getNode('message')->getAttribute('value');
+
+        $translationBundle = $this->getNode('translationBundle');
+
+        if ($translationBundle) {
+            $translationBundle = $translationBundle->getAttribute('value');
+        }
+
         $message = <<<CODE
 "<div class='alert alert-default alert-info'>
-    <strong>{$this->getNode('message')->getAttribute('value')}</strong>
-    <div>This file can be found in <code>{\$this->getTemplateName()}</code>.</div>
+    <strong>{$this->translator->trans($value, array(), $translationBundle)}</strong>
+    <div>{$this->translator->trans('sonata_core_template_box_file_found_in', array(), 'SonataCoreBundle')} <code>{\$this->getTemplateName()}</code>.</div>
 </div>"
 CODE;
 

--- a/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -12,18 +12,30 @@
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateBoxTokenParser extends \Twig_TokenParser
 {
-
+    /**
+     * @var bool
+     */
     protected $enabled;
 
     /**
-     * @param bool $enabled
+     * @var TranslatorInterface
      */
-    public function __construct($enabled)
+    protected $translator;
+
+    /**
+     * Constructor
+     *
+     * @param bool                $enabled    Is Symfony debug enabled?
+     * @param TranslatorInterface $translator Symfony Translator service
+     */
+    public function __construct($enabled, TranslatorInterface $translator)
     {
-        $this->enabled = $enabled;
+        $this->enabled    = $enabled;
+        $this->translator = $translator;
     }
 
     /**
@@ -37,9 +49,15 @@ class TemplateBoxTokenParser extends \Twig_TokenParser
             $message = new \Twig_Node_Expression_Constant('Template information', $token->getLine());
         }
 
+        if ($this->parser->getStream()->test(\Twig_Token::STRING_TYPE)) {
+            $translationBundle = $this->parser->getExpressionParser()->parseExpression();
+        } else {
+            $translationBundle = null;
+        }
+
         $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new TemplateBoxNode($message, $this->enabled, $token->getLine(), $this->getTag());
+        return new TemplateBoxNode($message, $translationBundle, $this->enabled, $this->translator, $token->getLine(), $this->getTag());
     }
 
     /**


### PR DESCRIPTION
I've updated `sonata_template_box` Twig node to allow translations.

This is not a BC break, it continues to work as normal with current tags:

``` jinja
{% sonata_template_box 'This is the gallery media block. Feel free to override' %}
```

and it can also take a translation key and a translation domain bundle name, like this:

``` jinja
{% sonata_template_box 'sonata_template_box_media_gallery_block' 'SonataDemoBundle' %}
```

and this will translate using the current locale, below in french:

![capture decran 2014-02-04 a 13 30 12](https://f.cloud.github.com/assets/103900/2075963/22a9fce0-8d98-11e3-9479-865daa5d93b0.png)
