### PR TITLE
Add missing translations for EqualType

### DIFF
--- a/Resources/translations/SonataCoreBundle.en.xliff
+++ b/Resources/translations/SonataCoreBundle.en.xliff
@@ -18,6 +18,14 @@
                 <source>sonata_core_template_box_file_found_in</source>
                 <target>This file can be found in</target>
             </trans-unit>
+            <trans-unit id="label_type_equals">
+                <source>label_type_equals</source>
+                <target>is equal to</target>
+            </trans-unit>
+            <trans-unit id="label_type_not_equals">
+                <source>label_type_not_equals</source>
+                <target>is not equal to</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
File 'Sonata/CoreBundle/Form/Type/EqualType.php' lines contains:
42: self::TYPE_IS_EQUAL => $this->translator->trans('label_type_equals', array(), 'SonataCoreBundle'),
43: self::TYPE_IS_NOT_EQUAL => $this->translator->trans('label_type_not_equals', array(), 'SonataCoreBundle'),

'label_type_equals' and 'label_type_not_equals' are used and are missing in translation files.
I copied them from SonataAdminBundle.
