### PR TITLE
Add request body param converter for APIs

### DIFF
--- a/Request/RequestBodyParamConverter.php
+++ b/Request/RequestBodyParamConverter.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Request;
+
+use FOS\RestBundle\Request\RequestBodyParamConverter20 as BaseRequestBodyParamConverter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ValidatorInterface;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+
+/**
+ * Defines correct class to use (entity or document) in param converter configuration
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class RequestBodyParamConverter extends BaseRequestBodyParamConverter
+{
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * Constructor
+     *
+     * @param object             $serializer
+     * @param array|null         $groups     An array of groups to be used in the serialization context
+     * @param string|null        $version    A version string to be used in the serialization context
+     * @param object             $serializer
+     * @param ValidatorInterface $validator
+     * @param string|null        $validationErrorsArgument
+     * @param array              $classes    Classes (entities or documents) to use
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($serializer, $groups = null, $version = null, ValidatorInterface $validator = null, $validationErrorsArgument = null, array $classes)
+    {
+        $this->classes = $classes;
+
+        parent::__construct($serializer, $groups, $version, $validator, $validationErrorsArgument);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function apply(Request $request, ConfigurationInterface $configuration)
+    {
+        $this->setConfigurationClass($configuration);
+
+        return $this->execute($request, $configuration);
+    }
+
+    /**
+     * Sets correct configuration class depending on available classes
+     *
+     * @param ConfigurationInterface $configuration
+     */
+    protected function setConfigurationClass(ConfigurationInterface $configuration)
+    {
+        foreach ($this->classes as $class) {
+            $reflectionClass = new \ReflectionClass($class);
+
+            if ($reflectionClass->isSubclassOf($configuration->getClass())) {
+                $configuration->setClass($class);
+                break;
+            }
+        }
+    }
+}

--- a/Tests/Request/RequestBodyParamConverterTest.php
+++ b/Tests/Request/RequestBodyParamConverterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Request;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sonata\CoreBundle\Request\RequestBodyParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class MyAbstractModel {
+
+}
+
+class MyModel extends MyAbstractModel {
+
+}
+
+class MyInvalidModel {
+
+}
+
+/**
+ * Class RequestBodyParamConverterTest
+ *
+ * This is the test class of the request body param converter used to retrieve non-abstract model
+ * classes used in bundles configuration
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class RequestBodyParamConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the apply() method
+     *
+     * Should return correct non-abstract class
+     */
+    public function testApply()
+    {
+        // Given
+        $request = new Request();
+        $serializer = $this->getMock('JMS\Serializer\SerializerInterface');
+
+        $configuration = new ParamConverter(array(
+            'class' => 'Sonata\CoreBundle\Tests\Request\MyAbstractModel'
+        ));
+
+        $classes = array('Sonata\CoreBundle\Tests\Request\MyModel');
+
+        $service = new RequestBodyParamConverter($serializer, null, null, null, null, $classes);
+
+        // When
+        $service->apply($request, $configuration);
+
+        // Then
+        $this->assertEquals('Sonata\CoreBundle\Tests\Request\MyModel', $configuration->getClass());
+    }
+
+    /**
+     * Tests the apply() method with an invalid class
+     *
+     * Should not alter the configuration class and return the model (abstract) class
+     */
+    public function testApplyInvalidClass()
+    {
+        // Given
+        $request = new Request();
+        $serializer = $this->getMock('JMS\Serializer\SerializerInterface');
+
+        $configuration = new ParamConverter(array(
+            'class' => 'Sonata\CoreBundle\Tests\Request\MyAbstractModel'
+        ));
+
+        $classes = array('Sonata\CoreBundle\Tests\Request\MyInvalidModel');
+
+        $service = new RequestBodyParamConverter($serializer, null, null, null, null, $classes);
+
+        // When
+        $service->apply($request, $configuration);
+
+        // Then
+        $this->assertEquals('Sonata\CoreBundle\Tests\Request\MyAbstractModel', $configuration->getClass());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,12 @@
         "twig/twig": "~1.12"
     },
     "require-dev": {
-        "sonata-project/exporter": "~1.3",
         "doctrine/orm": "~2.4",
-        "doctrine/phpcr-odm": "~1.0"
+        "doctrine/phpcr-odm": "~1.0",
+        "friendsofsymfony/rest-bundle": "~1.1",
+        "jms/serializer-bundle": "~0.11",
+        "sensio/framework-extra-bundle": "~2.2",
+        "sonata-project/exporter": "~1.3"
     },
     "autoload": {
         "psr-4": { "Sonata\\CoreBundle\\": "" }


### PR DESCRIPTION
In order to use serializations which are mapped on abstract models, I've added this service.

This service will be used by all different bundles to retrieve (non-abstract) entity or document classes defined in configuration.

To see an example, you can see what is done in my PR for SonataNewsBundle: https://github.com/sonata-project/SonataNewsBundle/pull/178/files#diff-649bcec1d33504d8c28a7d9ad16ae590R130
