### PR TITLE
Add Doctrine ORM serialization form type

### DIFF
--- a/Form/Type/DoctrineORMSerializationType.php
+++ b/Form/Type/DoctrineORMSerializationType.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Sonata\CoreBundle\Form\Type;
+
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+use Metadata\MetadataFactoryInterface;
+
+/**
+ * Class DoctrineORMSerializationType
+ *
+ * This is a doctrine serialization form type that generates a form type from class serialization metadata
+ * and doctrine metadata
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class DoctrineORMSerializationType extends AbstractType
+{
+    /**
+     * @var RegistryInterface
+     */
+    protected $registry;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    protected $metadataFactory;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var string
+     */
+    protected $group;
+
+    /**
+     * Constructor
+     *
+     * @param MetadataFactoryInterface $metadataFactory Serializer metadata factory
+     * @param RegistryInterface        $registry        Doctrine registry
+     * @param string                   $name            Form type name
+     * @param string                   $class           Data class name
+     * @param string                   $group           Serialization group name
+     */
+    public function __construct(MetadataFactoryInterface $metadataFactory, RegistryInterface $registry, $name, $class, $group)
+    {
+        $this->metadataFactory = $metadataFactory;
+        $this->registry = $registry;
+        $this->name  = $name;
+        $this->class = $class;
+        $this->group = $group;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $serializerMetadata = $this->metadataFactory->getMetadataForClass($this->class);
+
+        $manager = $this->registry->getManagerForClass($this->class);
+        $doctrineMetadata = $manager->getClassMetadata($this->class);
+
+        foreach ($serializerMetadata->propertyMetadata as $propertyMetadata) {
+            $name = $propertyMetadata->name;
+
+            if (in_array($name, $doctrineMetadata->getIdentifierFieldNames())) {
+                continue;
+            }
+
+            if (!in_array($this->group, $propertyMetadata->groups)) {
+                continue;
+            }
+
+            $nullable = true;
+
+            if (isset($doctrineMetadata->fieldMappings[$name])) {
+                $fieldMetadata = $doctrineMetadata->fieldMappings[$name];
+                $nullable = isset($fieldMetadata['nullable']) ? $fieldMetadata['nullable'] : false;
+            } else if (isset($doctrineMetadata->associationMappings[$name])) {
+                $associationMetadata = $doctrineMetadata->associationMappings[$name];
+
+                if (isset($associationMetadata['joinColumns']['nullable'])) {
+                    $nullable = $associationMetadata['joinColumns']['nullable'];
+                } else if (isset($associationMetadata['inverseJoinColumns']['nullable'])) {
+                    $nullable = $associationMetadata['inverseJoinColumns']['nullable'];
+                }
+            }
+
+            $builder->add($name, null, array('required' => !$nullable));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class
+        ));
+    }
+}

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -3,6 +3,34 @@ Form Types
 
 The bundle comes with some handy form types.
 
+DoctrineORMSerializationType
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This form type reads ``JMSSerializer`` serialization class metadata and uses ``Doctrine`` ORM entity metadata
+to generate form fields and correct types.
+
+All you have to do is to define a form type service for each entity for which you want to use a form type, like this:
+
+.. code-block:: xml
+
+    <service id="my.custom.form.type.post" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+        <tag name="form.type" alias="my_custom_form_type_comment" />
+
+        <argument type="service" id="jms_serializer.metadata_factory" />
+        <argument type="service" id="doctrine" />
+        <argument>my_custom_form_type_comment</argument>
+        <argument>My\CustomBundle\Entity\Comment</argument>
+        <argument>a_serialization_group</argument>
+    </service>
+
+The service definition should contain the following arguments:
+
+* The JMSSerializer metadata factory,
+* The Doctrine ORM entity manager,
+* The form type name,
+* The entity class name for which you want to build form,
+* The serialization group you want serialization fields have.
+
 sonata_type_immutable_array
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Form\Type;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo as DoctrineMetadata;
+
+use JMS\Serializer\Metadata\ClassMetadata as SerializerMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+
+use Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType;
+
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+
+/**
+ * Class FakeMetadataClass
+ */
+class FakeMetadataClass {
+    protected $name;
+
+    protected $url;
+
+    protected $comments;
+}
+
+/**
+ * Class DoctrineORMSerializationTypeTest
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class DoctrineORMSerializationTypeTest extends TypeTestCase
+{
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * Set up test
+     */
+    public function setUp()
+    {
+        if (!interface_exists('\Metadata\MetadataFactoryInterface') or !interface_exists('\Doctrine\ORM\EntityManagerInterface')) {
+            $this->markTestSkipped('Serializer and Doctrine has to be loaded to run this test');
+        }
+
+        parent::setUp();
+
+        $this->class = 'Sonata\CoreBundle\Tests\Form\Type\FakeMetadataClass';
+    }
+
+    /**
+     * Test form type buildForm() method that generates data
+     */
+    public function testBuildForm()
+    {
+        $metadataFactory = $this->getMetadataFactoryMock();
+        $registry = $this->getRegistryMock();
+
+        $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
+
+        $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
+
+        // Asserts that all 3 elements are in the form
+        $this->assertEquals(3, $form->count(), 'Should return 3 items in form');
+
+        // Assets that forms are correctly returned for correct fields
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('name'), 'Should return a form instance');
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('url'), 'Should return a form instance');
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('comments'), 'Should return a form instance');
+
+        // Asserts that required fields / associations rules are correctly parsed
+        $this->assertFalse($form->get('name')->isRequired(), 'Should return a non-required field');
+        $this->assertTrue($form->get('url')->isRequired(), 'Should return a required field');
+        $this->assertFalse($form->get('comments')->isRequired(), 'Should return a non-required field');
+    }
+
+    /**
+     * Test form type buildForm() method that generates data with an identifier field
+     */
+    public function testBuildFormWithIdentifier()
+    {
+        $metadataFactory = $this->getMetadataFactoryMock();
+        $registry = $this->getRegistryMock(array('name'));
+
+        $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
+
+        $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
+
+        // Assets that forms have only 2 generated fields as the third is an identifier
+        $this->assertEquals(2, $form->count(), 'Should return 2 elements in the form');
+
+        // Assets that forms are correctly returned for correct fields
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('url'), 'Should return a form instance');
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('comments'), 'Should return a form instance');
+    }
+
+    /**
+     * Test form type buildForm() method that generates data with an invalid group name
+     */
+    public function testBuildFormWithInvalidGroupName()
+    {
+        $metadataFactory = $this->getMetadataFactoryMock();
+        $registry = $this->getRegistryMock(array('name'));
+
+        $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_invalid');
+
+        $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
+
+        // Assets that forms have no generated field as group is invalid
+        $this->assertEquals(0, $form->count(), 'Should return 0 elements as given form type group is invalid');
+    }
+
+    /**
+     * Returns a Serializer MetadataFactory mock
+     *
+     * @return \Metadata\MetadataFactoryInterface
+     */
+    protected function getMetadataFactoryMock()
+    {
+        $name = new PropertyMetadata($this->class, 'name');
+        $name->groups = array('serialization_api_write');
+
+        $url = new PropertyMetadata($this->class, 'url');
+        $url->groups = array('serialization_api_write');
+
+        $comments = new PropertyMetadata($this->class, 'comments');
+        $comments->groups = array('serialization_api_write');
+
+        $classMetadata = new SerializerMetadata($this->class);
+        $classMetadata->addPropertyMetadata($name);
+        $classMetadata->addPropertyMetadata($url);
+        $classMetadata->addPropertyMetadata($comments);
+
+        $metadataFactory = $this->getMock('Metadata\MetadataFactoryInterface');
+        $metadataFactory->expects($this->once())->method('getMetadataForClass')->will($this->returnValue($classMetadata));
+
+        return $metadataFactory;
+    }
+
+    /**
+     * Returns a Doctrine registry mock
+     *
+     * @param array $identifiers
+     *
+     * @return \Symfony\Bridge\Doctrine\RegistryInterface
+     */
+    protected function getRegistryMock($identifiers = array())
+    {
+        $classMetadata = new DoctrineMetadata($this->class);
+        $classMetadata->identifier = $identifiers;
+
+        $classMetadata->fieldMappings = array('name' => array(
+            'nullable' => true,
+        ));
+
+        $classMetadata->associationMappings = array(
+            'url' => array(
+                'joinColumns' => array('nullable' => false)
+            ),
+            'comments' => array(
+                'inverseJoinColumns' => array('nullable' => true)
+            )
+        );
+
+        $entityManager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $entityManager->expects($this->once())->method('getClassMetadata')->will($this->returnValue($classMetadata));
+
+        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($entityManager));
+
+        return $registry;
+    }
+}


### PR DESCRIPTION
Here is a `DoctrineORMSerializationType` form type.

This form type reads `JMSSerializer` serialization class metadata and uses `Doctrine` ORM entity metadata
to generate form fields and correct types.

All you have to do is to define a form type service for each entity for which you want to use a form type, like this:

``` xml
<service id="my.custom.form.type.post" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
    <tag name="form.type" alias="my_custom_form_type_comment" />

    <argument type="service" id="jms_serializer.metadata_factory" />
    <argument type="service" id="doctrine" />
    <argument>my_custom_form_type_comment</argument>
    <argument>My\CustomBundle\Entity\Comment</argument>
    <argument>a_serialization_group</argument>
</service>
```

The service definition should contain the following arguments:
- The JMSSerializer metadata factory,
- The Doctrine registry,
- The form type name,
- The entity class name for which you want to build form,
- The serialization group you want serialization fields have.
