### PR TITLE
replace error type key with danger

### DIFF
--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -81,7 +81,7 @@ class SonataCoreExtension extends Extension
                 'warning' => array('domain' => 'SonataCoreBundle'),
                 'sonata_flash_info' => array('domain' => 'SonataAdminBundle'),
             )),
-            'error' => array('types' => array(
+            'danger' => array('types' => array(
                 'error' => array('domain' => 'SonataCoreBundle'),
                 'sonata_flash_error' => array('domain' => 'SonataAdminBundle'),
                 'sonata_user_error'  => array('domain' => 'SonataUserBundle'),


### PR DESCRIPTION
The alert-error CSS class has been deprecated in favor of alert-danger
in Bootstrap 3. This commit makes sure error alert boxes are red.
