### PR TITLE
Fix recursive field creation

### DIFF
--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -53,7 +53,7 @@ class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults(array(
             'field_options'    => array(),
-            'field_type'       => 'sonata_type_datetime_range'
+            'field_type'       => 'datetime',
         ));
     }
 }


### PR DESCRIPTION
The default field type causes recursive 'sonata_type_datetime_range' field creation. Changed it back to 'datetime'
