### PR TITLE
removed form-group

### DIFF
--- a/Resources/views/Form/datepicker.html.twig
+++ b/Resources/views/Form/datepicker.html.twig
@@ -10,12 +10,10 @@ file that was distributed with this source code.
 #}
 {% block sonata_type_date_picker_widget %}
     {% spaceless %}
-        <div class="form-group">
-            <div class='input-group date' id='{{ id }}' data-date-format="{{ moment_format }}">
-                {{ block('date_widget') }}
-                <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span>
-                </span>
-            </div>
+        <div class='input-group date' id='{{ id }}' data-date-format="{{ moment_format }}">
+            {{ block('date_widget') }}
+            <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span>
+            </span>
         </div>
         <script type="text/javascript">
             jQuery(function ($) {
@@ -27,12 +25,10 @@ file that was distributed with this source code.
 
 {% block sonata_type_datetime_picker_widget %}
     {% spaceless %}
-        <div class="form-group">
-            <div class='input-group date' id='{{ id }}' data-date-format="{{ moment_format }}">
-                {{ block('datetime_widget') }}
-                <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span>
-                </span>
-            </div>
+        <div class='input-group date' id='{{ id }}' data-date-format="{{ moment_format }}">
+            {{ block('datetime_widget') }}
+            <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span>
+            </span>
         </div>
         <script type="text/javascript">
             jQuery(function ($) {


### PR DESCRIPTION
there is already a form-group. when using "form-horizontal" class, there is an additional substraction of 15px margin on both sides of the element caused by

```
.form-horizontal .form-group {
   margin-left: -15px;
   margin-right: -15px;
}
```

![image](https://cloud.githubusercontent.com/assets/241080/3131296/e5c3000e-e802-11e3-95d5-1ddf5555c627.png)
