### PR TITLE
Fix cache clearing in prod

### DIFF
--- a/Twig/Node/TemplateBoxNode.php
+++ b/Twig/Node/TemplateBoxNode.php
@@ -52,7 +52,7 @@ class TemplateBoxNode extends \Twig_Node
             ->addDebugInfo($this);
 
         if (!$this->enabled) {
-            $compiler->write("// token for sonata_template_box, however the box is disabled");
+            $compiler->write("// token for sonata_template_box, however the box is disabled\n");
             return;
         }
 


### PR DESCRIPTION
Hello ! 

When I use the tag "sonata_template_box" and I clear the cache in prod environment, the cache clearing fails.  This is the error I get :

```
Clearing the cache for the prod environment with debug false
PHP Parse error:  syntax error, unexpected '<' in /var/www/test/app/cache/pro_/twig/68/d8/a4fd9d13de9ec3a0dd5619ca8d48cdcd44c17790caffcd939e6119dad843.php on line 41
PHP Stack trace:
PHP   1. {main}() /var/www/test/app/console:0
PHP   2. Symfony\Component\Console\Application->run() /var/www/test/app/console:27
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /var/www/test/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRun() /var/www/test/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96
PHP   5. Symfony\Component\Console\Application->doRunCommand() /var/www/test/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:193
PHP   6. Symfony\Component\Console\Command\Command->run() /var/www/test/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:894
PHP   7. Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() /var/www/test/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:252
PHP   8. Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->warmup() /var/www/test/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:90
PHP   9. Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() /var/www/test/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php:135
PHP  10. Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer->warmUp() /var/www/test/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php:48
PHP  11. Twig_Environment->loadTemplate() /var/www/test/vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php:62
```

And the file causing the problem contains :

``` php
    // line 5
    public function block_body($context, array $blocks = array())
    {
        // line 6
        echo "    ";
        // token for sonata_template_box, however the box is disabled        echo "  
    <section class=\"panel\">
";
        // line 11
        echo "        <div class=\"panel-body\">
            ";
```

We can easily see that there is a problem of newline after the comment. So that's why I made this PR. It solves the problem and the cache is now clearing correctly. 

Thanks !
