### PR TITLE
Hungarian translations are missing for two strings

### DIFF
--- a/Resources/translations/SonataCoreBundle.hu.xliff
+++ b/Resources/translations/SonataCoreBundle.hu.xliff
@@ -16,11 +16,11 @@
             </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
-                <target>label_type_equals</target>
+                <target>egyenlő</target>
             </trans-unit>
             <trans-unit id="label_type_not_equals">
                 <source>label_type_not_equals</source>
-                <target>label_type_not_equals</target>
+                <target>nem egyenlő</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
The label_type_equals and label_type_not_equals strings were not translated. I've copied the translations from SonataAdminBundle.hu.xliff, because the translations for these strings are exist in that file.
