### PR TITLE
Temporary fix for checkbox input not set to false

### DIFF
--- a/Form/EventListener/FixCheckboxDataListener.php
+++ b/Form/EventListener/FixCheckboxDataListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Form\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Using BooleanToStringTransform in a checkbox form type
+ * will set false value to '0' instead of null which will end up
+ * returning true value when the form is bind
+ *
+ * Class FixCheckboxDataListener
+ *
+ * @author  Sylvain Rascar <rascar.sylvain@gmail.com>
+ *
+ * @package Sonata\CoreBundle\Form\EventListener
+ */
+class FixCheckboxDataListener implements EventSubscriberInterface
+{
+    /**
+     * @param FormEvent $event
+     */
+    public function preSubmit(FormEvent $event)
+    {
+        $data = $event->getData();
+        $transformers = $event->getForm()->getConfig()->getViewTransformers();
+
+        if (count($transformers) === 1 && $transformers[0] instanceof BooleanToStringTransformer && $data === '0') {
+            $event->setData(null);
+        }
+    }
+
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     *
+     * @param FormEvent $event
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(FormEvents::PRE_SUBMIT => 'preSubmit');
+    }
+}

--- a/Form/Type/DoctrineORMSerializationType.php
+++ b/Form/Type/DoctrineORMSerializationType.php
@@ -13,6 +13,7 @@
 namespace Sonata\CoreBundle\Form\Type;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Sonata\CoreBundle\Form\EventListener\FixCheckboxDataListener;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
 use Symfony\Component\Form\AbstractType;
@@ -116,6 +117,12 @@ class DoctrineORMSerializationType extends AbstractType
             switch ($type) {
                 case 'datetime':
                     $builder->add($name, $type, array('required' => !$nullable, 'widget' => 'single_text'));
+                    break;
+
+                case 'boolean':
+                    $childBuilder = $builder->create($name, null, array('required' => !$nullable));
+                    $childBuilder->addEventSubscriber(new FixCheckboxDataListener());
+                    $builder->add($childBuilder);
                     break;
 
                 default:

--- a/Tests/Form/EventListener/FixCheckboxDataListenerTest.php
+++ b/Tests/Form/EventListener/FixCheckboxDataListenerTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Form\EventListener;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
+use Sonata\CoreBundle\Form\EventListener\FixCheckboxDataListener;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Forms;
+
+class FixCheckboxDataListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider valuesProvider
+     */
+    public function testFixCheckbox($data, $expected, $suscriber, $transformer)
+    {
+        $dispatcher = new EventDispatcher();
+
+        if ($suscriber) {
+            $dispatcher->addSubscriber($suscriber);
+        }
+
+        $formFactory = Forms::createFormFactoryBuilder()
+            ->addExtensions(array())
+            ->getFormFactory();
+
+        $formBuilder = new FormBuilder('checkbox', 'stdClass', $dispatcher, $formFactory);
+
+        if ($transformer) {
+            $formBuilder->addViewTransformer($transformer);
+        }
+
+        $form = $formBuilder->getForm();
+        $form->submit($data);
+
+        $this->assertEquals($expected, $form->getData());
+    }
+
+    public function valuesProvider()
+    {
+        return array(
+            array('0', true, null, new BooleanToStringTransformer('1')),
+            array('0', false, new FixCheckboxDataListener(), new BooleanToStringTransformer('1')),
+        );
+    }
+}


### PR DESCRIPTION
This PR fix issues on api when boolean values are never set to false