### PR TITLE
patched inline validation error

### DIFF
--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -53,6 +53,7 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('date.xml');
         $loader->load('flash.xml');
         $loader->load('form_types.xml');
+        $loader->load('validator.xml');
         $loader->load('twig.xml');
         $loader->load('model_adapter.xml');
         $loader->load('core.xml');

--- a/Resources/config/validator.xml
+++ b/Resources/config/validator.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.core.validator.inline" class="Sonata\CoreBundle\Validator\InlineValidator">
+            <argument type="service" id="service_container" />
+            <argument type="service" id="validator.validator_factory" />
+
+            <tag name="validator.constraint_validator" alias="sonata.core.validator.inline" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
After this patch new objects could be created in the SonataAdmin again, but this is not the resolution of the bug.
(CoreBundle and AdminBundle are messed up)