### PR TITLE
Added support for field_options_start and field_options_end in DateTimeRangeType and DateRangeType, added label translations

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -34,8 +34,22 @@ class DateRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('start', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
-        $builder->add('end', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
+        $options['field_options_start'] = array_merge(
+            array(
+                'label' => $this->translator->trans('date_range_start', array(), 'SonataCoreBundle')
+            ),
+            $options['field_options_start']
+        );
+
+        $options['field_options_end'] = array_merge(
+            array(
+                'label' => $this->translator->trans('date_range_end', array(), 'SonataCoreBundle')
+            ),
+            $options['field_options_end']
+        );
+
+        $builder->add('start', $options['field_type'], array_merge(array('required' => false), $options['field_options'], $options['field_options_start']));
+        $builder->add('end', $options['field_type'], array_merge(array('required' => false), $options['field_options'], $options['field_options_end']));
     }
 
     /**
@@ -52,8 +66,10 @@ class DateRangeType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'field_options'    => array(),
-            'field_type'       => 'date'
+            'field_options'       => array(),
+            'field_options_start' => array(),
+            'field_options_end'   => array(),
+            'field_type'          => 'date'
         ));
     }
 }

--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -34,8 +34,22 @@ class DateTimeRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('start', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
-        $builder->add('end', $options['field_type'], array_merge(array('required' => false), $options['field_options']));
+        $options['field_options_start'] = array_merge(
+            array(
+                'label' => $this->translator->trans('date_range_start', array(), 'SonataCoreBundle')
+            ),
+            $options['field_options_start']
+        );
+
+        $options['field_options_end'] = array_merge(
+            array(
+                'label' => $this->translator->trans('date_range_end', array(), 'SonataCoreBundle')
+            ),
+            $options['field_options_end']
+        );
+
+        $builder->add('start', $options['field_type'], array_merge(array('required' => false), $options['field_options'], $options['field_options_start']));
+        $builder->add('end', $options['field_type'], array_merge(array('required' => false), $options['field_options'], $options['field_options_end']));
     }
 
     /**
@@ -52,8 +66,10 @@ class DateTimeRangeType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'field_options'    => array(),
-            'field_type'       => 'datetime',
+            'field_options'       => array(),
+            'field_options_start' => array(),
+            'field_options_end'   => array(),
+            'field_type'          => 'datetime',
         ));
     }
 }

--- a/Resources/translations/SonataCoreBundle.ar.xliff
+++ b/Resources/translations/SonataCoreBundle.ar.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>لا تساوي</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.bg.xliff
+++ b/Resources/translations/SonataCoreBundle.bg.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>не съвпада със</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.ca.xliff
+++ b/Resources/translations/SonataCoreBundle.ca.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>no és igual a</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.cs.xliff
+++ b/Resources/translations/SonataCoreBundle.cs.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nerovná se</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>Od</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>Do</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.de.xliff
+++ b/Resources/translations/SonataCoreBundle.de.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>ist nicht gleich</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.en.xliff
+++ b/Resources/translations/SonataCoreBundle.en.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>is not equal to</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>From</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>To</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.es.xliff
+++ b/Resources/translations/SonataCoreBundle.es.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>diferente a</target>
             </trans-unit>
-            </body>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
+        </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.eu.xliff
+++ b/Resources/translations/SonataCoreBundle.eu.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>ez da berdina</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.fa.xliff
+++ b/Resources/translations/SonataCoreBundle.fa.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>برابر نیست با</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.fr.xliff
+++ b/Resources/translations/SonataCoreBundle.fr.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>Ne contient pas</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.hr.xliff
+++ b/Resources/translations/SonataCoreBundle.hr.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nije jednak</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.hu.xliff
+++ b/Resources/translations/SonataCoreBundle.hu.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nem egyenlő</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.it.xliff
+++ b/Resources/translations/SonataCoreBundle.it.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>non è uguale a</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.ja.xliff
+++ b/Resources/translations/SonataCoreBundle.ja.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>等しくない</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.lb.xliff
+++ b/Resources/translations/SonataCoreBundle.lb.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>label_type_not_equals</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.lt.xliff
+++ b/Resources/translations/SonataCoreBundle.lt.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nelygus</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.nl.xliff
+++ b/Resources/translations/SonataCoreBundle.nl.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>is niet gelijk aan</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.pl.xliff
+++ b/Resources/translations/SonataCoreBundle.pl.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nie jest równe</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.pt.xliff
+++ b/Resources/translations/SonataCoreBundle.pt.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>não é igual a</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.pt_BR.xliff
+++ b/Resources/translations/SonataCoreBundle.pt_BR.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>não é igual a</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.ro.xliff
+++ b/Resources/translations/SonataCoreBundle.ro.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>nu este egal cu</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.ru.xliff
+++ b/Resources/translations/SonataCoreBundle.ru.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>не равен</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.sk.xliff
+++ b/Resources/translations/SonataCoreBundle.sk.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>sa nerovná</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>Od</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>Do</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.sl.xliff
+++ b/Resources/translations/SonataCoreBundle.sl.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>ni enako</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.uk.xliff
+++ b/Resources/translations/SonataCoreBundle.uk.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>не дорівнює</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataCoreBundle.zh_CN.xliff
+++ b/Resources/translations/SonataCoreBundle.zh_CN.xliff
@@ -26,6 +26,14 @@
                 <source>label_type_not_equals</source>
                 <target>label_type_not_equals</target>
             </trans-unit>
+            <trans-unit id="date_range_start">
+                <source>date_range_start</source>
+                <target>date_range_start</target>
+            </trans-unit>
+            <trans-unit id="date_range_end">
+                <source>date_range_end</source>
+                <target>date_range_end</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Form/Type/DateRangeTypeTest.php
+++ b/Tests/Form/Type/DateRangeTypeTest.php
@@ -29,6 +29,12 @@ class DateRangeTypeTest extends TypeTestCase
 
         $options = $resolver->resolve();
 
-        $this->assertEquals(array('field_options' => array(), 'field_type' => 'date'), $options);
+        $this->assertEquals(
+            array(
+                'field_options' => array(),
+                'field_options_start'=>array(),
+                'field_options_end'=>array(),
+                'field_type' => 'date'
+            ), $options);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (there was no option to translate the labels)
| New feature?  | yes 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #110
| License       | MIT

This PR replaces #124 and brings more options to customize the `start` and `end` form type of date(time) range type.