### PR TITLE
Improved datetime picker form type

### DIFF
--- a/Date/MomentFormatConverter.php
+++ b/Date/MomentFormatConverter.php
@@ -8,10 +8,8 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Sonata\CoreBundle\Date;
 
-use Sonata\CoreBundle\Exception\InvalidParameterException;
 
 
 /**
@@ -21,40 +19,41 @@ use Sonata\CoreBundle\Exception\InvalidParameterException;
  *
  * @package Sonata\CoreBundle\Date
  *
- * @author Hugo Briand <briand@ekino.com>,
+ * @author Hugo Briand <briand@ekino.com>
+ * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class MomentFormatConverter
 {
     /**
      * @var array This defines the mapping between PHP ICU date format (key) and moment.js date format (value)
-     * For ICU formats see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
-     * For Moment formats see http://momentjs.com/docs/#/displaying/format/
+     *            For ICU formats see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
+     *            For Moment formats see http://momentjs.com/docs/#/displaying/format/
      */
     private static $formatConvertRules = array(
         // year
-        'yyyy'=>'YYYY', 'yy'=>'YY',
+        'yyyy' => 'YYYY', 'yy' => 'YY',
         // month
-        'MMMM'=>'MMMM', 'MMM'=>'MMM', 'MM'=>'MM',
+        // 'MMMM'=>'MMMM', 'MMM'=>'MMM', 'MM'=>'MM',
         // day
-        'dd'=>'DD', 'd'=>'D',
+        'dd' => 'DD', 'd' => 'D',
         // hour
-        'HH'=>'HH', 'H'=>'H', 'h'=>'h', 'hh'=>'hh',
+        // 'HH'=>'HH', 'H'=>'H', 'h'=>'h', 'hh'=>'hh',
         // am/pm
-        'a' => 'a',
+        // 'a' => 'a',
         // minute
-        'mm'=>'mm', 'm'=>'m',
+        // 'mm'=>'mm', 'm'=>'m',
         // second
-        'ss'=>'ss', 's'=>'s',
+        // 'ss'=>'ss', 's'=>'s',
         // day of week
-        'EE'=>'ddd', 'EEEEEE'=>'dd',
+        'EE' => 'ddd', 'EEEEEE' => 'dd',
         // timezone
-        'ZZZZZ' => 'Z', 'ZZZ'=>'ZZ',
+        'ZZZZZ' => 'Z', 'ZZZ' => 'ZZ',
         // letter 'T'
         '\'T\'' => 'T',
     );
 
     /**
-     * If $format is recognized, returns associated moment.js format, throws exception otherwise.
+     * Returns associated moment.js format.
      *
      * @param $format PHP Date format
      *

--- a/Date/MomentFormatConverter.php
+++ b/Date/MomentFormatConverter.php
@@ -30,20 +30,27 @@ class MomentFormatConverter
      * For ICU formats see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
      * For Moment formats see http://momentjs.com/docs/#/displaying/format/
      */
-    private $phpMomentMapping = array(
-        "yyyy-MM-dd'T'HH:mm:ssZZZZZ" => 'YYYY-MM-DDTHH:mm:ssZZ', // 2014-05-14T13:55:01+02:00
-        "yyyy-MM-dd HH:mm:ss"        => 'YYYY-MM-DD HH:mm:ss',   // 2014-05-14 13:55:01, timestamp without timezone
-        "yyyy-MM-dd HH:mm"           => 'YYYY-MM-DD HH:mm',      // 2014-05-14 13:55:01, timestamp without timezone or seconds
-        "yyyy-MM-dd"                 => 'YYYY-MM-DD',            // 2014-05-14
-        "dd.MM.yyyy, HH:mm"          => 'DD.MM.YYYY, HH:mm',     // 14.05.2014, 13:55, German format without seconds
-        "dd.MM.yyyy, HH:mm:ss"       => 'DD.MM.YYYY, HH:mm:ss',  // 14.05.2014, 13:55:01, German format with seconds
-        "dd.MM.yyyy"                 => 'DD.MM.YYYY',            // 14.05.2014, German format without time
-        "dd/MM/yyyy"                 => 'DD/MM/YYYY',            // 14/05/2014, British ascending format
-        "dd/MM/yyyy HH:mm"           => 'DD/MM/YYYY HH:mm',      // 14/05/2014 13:55, British ascending format with time
-        "EE, dd/MM/yyyy HH:mm"       => 'ddd, DD/MM/YYYY HH:mm', // Wed, 14/05/2014 13:55, includes day of week in British format
-        "dd-MM-yyyy"                 => 'DD-MM-YYYY',            // 14-05-2014, Dutch format
-        "dd-MM-yyyy HH:mm"           => 'DD-MM-YYYY HH:mm',      // 14-05-2014 13:55, Dutch format with time
-        "dd-MM-yyyy HH:mm:ss"        => 'DD-MM-YYYY HH:mm:ss',   // 14-05-2014 13:55:01, Dutch format with time and seconds
+    private static $formatConvertRules = array(
+        // year
+        'yyyy'=>'YYYY', 'yy'=>'YY',
+        // month
+        'MMMM'=>'MMMM', 'MMM'=>'MMM', 'MM'=>'MM',
+        // day
+        'dd'=>'DD', 'd'=>'D',
+        // hour
+        'HH'=>'HH', 'H'=>'H', 'h'=>'h', 'hh'=>'hh',
+        // am/pm
+        'a' => 'a',
+        // minute
+        'mm'=>'mm', 'm'=>'m',
+        // second
+        'ss'=>'ss', 's'=>'s',
+        // day of week
+        'EE'=>'ddd', 'EEEEEE'=>'dd',
+        // timezone
+        'ZZZZZ' => 'Z', 'ZZZ'=>'ZZ',
+        // letter 'T'
+        '\'T\'' => 'T',
     );
 
     /**
@@ -52,14 +59,9 @@ class MomentFormatConverter
      * @param $format PHP Date format
      *
      * @return string Moment.js date format
-     * @throws \Sonata\CoreBundle\Exception\InvalidParameterException If format not found
      */
     public function convert($format)
     {
-        if (!array_key_exists($format, $this->phpMomentMapping)) {
-            throw new InvalidParameterException(sprintf("PHP Date format '%s' is not a convertible moment.js format; please add it to the 'Sonata\CoreBundle\Date\MomentFormatConverter' class by submitting a pull request if you want it supported.", $format));
-        }
-
-        return $this->phpMomentMapping[$format];
+        return strtr($format, self::$formatConvertRules);
     }
 }

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -8,12 +8,10 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 
 /**
  * Class DatePickerType
@@ -31,6 +29,7 @@ class DatePickerType extends BasePickerType
     {
         $resolver->setDefaults(array_merge($this->getCommonDefaults(), array(
             'dp_pick_time' => false,
+            'format'       => DateType::DEFAULT_FORMAT,
         )));
     }
 
@@ -48,13 +47,5 @@ class DatePickerType extends BasePickerType
     public function getName()
     {
         return 'sonata_type_date_picker';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefaultFormat()
-    {
-        return DateType::HTML5_FORMAT;
     }
 }

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -8,12 +8,10 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 
 /**
  * Class DatePickerType
@@ -33,6 +31,8 @@ class DateTimePickerType extends BasePickerType
             'dp_use_minutes'     => true,
             'dp_use_seconds'     => true,
             'dp_minute_stepping' => 1,
+            'format'             => DateTimeType::DEFAULT_DATE_FORMAT,
+            'date_format'        => null,
         )));
     }
 
@@ -50,13 +50,5 @@ class DateTimePickerType extends BasePickerType
     public function getName()
     {
         return 'sonata_type_datetime_picker';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefaultFormat()
-    {
-        return DateTimeType::HTML5_FORMAT;
     }
 }

--- a/Tests/Date/MomentFormatConverterTest.php
+++ b/Tests/Date/MomentFormatConverterTest.php
@@ -28,22 +28,34 @@ class MomentFormatConverterTest extends \PHPUnit_Framework_TestCase
         $mfc = new MomentFormatConverter();
 
         $phpFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
-        $this->assertEquals("YYYY-MM-DDTHH:mm:ssZZ", $mfc->convert($phpFormat));
-        
+        $this->assertEquals("YYYY-MM-DDTHH:mm:ssZ", $mfc->convert($phpFormat));
+
         $phpFormat = "yyyy-MM-dd HH:mm:ss";
         $this->assertEquals("YYYY-MM-DD HH:mm:ss", $mfc->convert($phpFormat));
-        
+
         $phpFormat = "yyyy-MM-dd HH:mm";
         $this->assertEquals("YYYY-MM-DD HH:mm", $mfc->convert($phpFormat));
-        
+
         $phpFormat = "yyyy-MM-dd";
         $this->assertEquals("YYYY-MM-DD", $mfc->convert($phpFormat));
-        
+
         $phpFormat = "dd.MM.yyyy, HH:mm";
         $this->assertEquals("DD.MM.YYYY, HH:mm", $mfc->convert($phpFormat));
-        
+
         $phpFormat = "dd.MM.yyyy, HH:mm:ss";
         $this->assertEquals("DD.MM.YYYY, HH:mm:ss", $mfc->convert($phpFormat));
+
+        $phpFormat = "dd.MM.yyyy";
+        $this->assertEquals("DD.MM.YYYY", $mfc->convert($phpFormat));
+
+        $phpFormat = "d.M.yyyy";
+        $this->assertEquals("D.M.YYYY", $mfc->convert($phpFormat));
+
+        $phpFormat = "d.M.yyyy HH:mm";
+        $this->assertEquals("D.M.YYYY HH:mm", $mfc->convert($phpFormat));
+
+        $phpFormat = "d.M.yyyy HH:mm:ss";
+        $this->assertEquals("D.M.YYYY HH:mm:ss", $mfc->convert($phpFormat));
 
         $phpFormat = "dd/MM/yyyy";
         $this->assertEquals("DD/MM/YYYY", $mfc->convert($phpFormat));
@@ -53,17 +65,14 @@ class MomentFormatConverterTest extends \PHPUnit_Framework_TestCase
 
         $phpFormat = "EE, dd/MM/yyyy HH:mm";
         $this->assertEquals("ddd, DD/MM/YYYY HH:mm", $mfc->convert($phpFormat));
-    }
 
-    /**
-     * @expectedException        Sonata\CoreBundle\Exception\InvalidParameterException
-     * @expectedExceptionMessage PHP Date format 'unexisting format' is not a convertible moment.js format; please add it to the 'Sonata\CoreBundle\Date\MomentFormatConverter' class by submitting a pull request if you want it supported.
-     */
-    public function testPhpToMomentUnsupported()
-    {
-        $mfc = new MomentFormatConverter();
-        $unexistingFormat = "unexisting format";
+        $phpFormat = "dd-MM-yyyy";
+        $this->assertEquals("DD-MM-YYYY", $mfc->convert($phpFormat));
 
-        $mfc->convert($unexistingFormat);
+        $phpFormat = "dd-MM-yyyy HH:mm";
+        $this->assertEquals("DD-MM-YYYY HH:mm", $mfc->convert($phpFormat));
+
+        $phpFormat = "dd-MM-yyyy HH:mm:ss";
+        $this->assertEquals("DD-MM-YYYY HH:mm:ss", $mfc->convert($phpFormat));
     }
 }

--- a/Tests/Form/Type/BasePickerTypeTest.php
+++ b/Tests/Form/Type/BasePickerTypeTest.php
@@ -8,7 +8,6 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
@@ -30,7 +29,6 @@ class BasePickerTest extends BasePickerType
     }
 }
 
-
 /**
  * Class BasePickerTypeTest
  *
@@ -47,7 +45,7 @@ class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
         $view = new FormView();
         $form = new Form($this->getMock('Symfony\Component\Form\FormConfigInterface'));
 
-        $type->finishView($view, $form, array());
+        $type->finishView($view, $form, array('format' => 'yyyy-MM-dd'));
 
         $this->assertArrayHasKey('moment_format', $view->vars);
         $this->assertArrayHasKey('dp_options', $view->vars);


### PR DESCRIPTION
This PR make two improvements in picker form types:
- The `MomentFormatConverter` is now converting any datetime format to moment-js format, not just the whitelisted.
- The `sonata_type_date_picker` and `sonata_type_datetime_picker` are localized by default in current `locale` and using localized date(time) format. This PR deprecates #113.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #80, #98
| License       | MIT
