### PR TITLE
correct datepicker input wrapper class

### DIFF
--- a/Resources/views/Form/datepicker.html.twig
+++ b/Resources/views/Form/datepicker.html.twig
@@ -23,7 +23,7 @@ file that was distributed with this source code.
 {% block sonata_type_date_picker_widget %}
     {% spaceless %}
         {% if wrap_fields_with_addons %}
-            <div class="form-group">
+            <div class="input-group">
                 {{ block('sonata_type_date_picker_widget_html') }}
             </div>
         {% else %}
@@ -52,7 +52,7 @@ file that was distributed with this source code.
 {% block sonata_type_datetime_picker_widget %}
     {% spaceless %}
         {% if wrap_fields_with_addons %}
-            <div class="form-group">
+            <div class="input-group">
                 {{ block('sonata_type_datetime_picker_widget_html') }}
             </div>
         {% else %}


### PR DESCRIPTION
The datepicker wrapper class was erroneously set as "form-control" this caused issues with help blocks and other elements.