### PR TITLE
Adding double quote to filename attachment header

### DIFF
--- a/Exporter/Exporter.php
+++ b/Exporter/Exporter.php
@@ -60,7 +60,7 @@ class Exporter
 
         return new StreamedResponse($callback, 200, array(
             'Content-Type'        => $contentType,
-            'Content-Disposition' => sprintf('attachment; filename=%s', $filename)
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $filename)
         ));
     }
 }

--- a/Tests/Exporter/ExporterTest.php
+++ b/Tests/Exporter/ExporterTest.php
@@ -42,7 +42,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals($contentType, $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename='.$filename, $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename="'.$filename.'"', $response->headers->get('Content-Disposition'));
     }
 
     public function getGetResponseTests()


### PR DESCRIPTION
As of http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1 filename should be inside double-quote.