### PR TITLE
Fix : Cannot use object of type [Object] as array in preSubmit Event

### DIFF
--- a/Form/EventListener/ResizeFormListener.php
+++ b/Form/EventListener/ResizeFormListener.php
@@ -163,7 +163,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 $form->add($name, $this->type, $options);
             }
 
-            if (isset($value['_delete'])) {
+            if (is_array($value) && isset($value['_delete'])) {
                 $this->removed[] = $name;
             }
         }


### PR DESCRIPTION
Hey,

Since the changes from #162, I have an error when trying to add a new entity from a form with a field of type sonata_type_collection.
The $value is an object in some cases. (when there's at least one entity in the collection).

My form was working before this update.

Example Error: Cannot use object of type AppBundle\Entity\MyEntity as array
in vendor/sonata-project/core-bundle/Form/EventListener/ResizeFormListener.php at line 165