### PR TITLE
Fix datepicker and datetimepicker (basepicker) locale

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class BasePickerType (to factorize DatePickerType and DateTimePickerType code.
@@ -31,11 +32,30 @@ abstract class BasePickerType extends AbstractType
     private $formatConverter;
 
     /**
-     * @param MomentFormatConverter $formatConverter
+     * @var TranslatorInterface
      */
-    public function __construct(MomentFormatConverter $formatConverter)
+    protected $translator;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @param MomentFormatConverter $formatConverter
+     * @param TranslatorInterface   $translator
+     */
+    public function __construct(MomentFormatConverter $formatConverter, TranslatorInterface $translator = null)
     {
         $this->formatConverter = $formatConverter;
+        $this->translator = $translator;
+
+        if (null !== $this->translator) {
+            $this->locale = $this->translator->getLocale();
+        } else {
+            @trigger_error('Initializing '.__CLASS__.' without TranslatorInterface is deprecated since 2.4 and will be remove in 3.0.', E_USER_DEPRECATED);
+            $this->locale = \Locale::getDefault();
+        }
     }
 
     /**
@@ -92,7 +112,7 @@ abstract class BasePickerType extends AbstractType
             'dp_min_date'              => '1/1/1900',
             'dp_max_date'              => null,
             'dp_show_today'            => true,
-            'dp_language'              => \Locale::getDefault(), // 'en'
+            'dp_language'              => $this->locale,
             'dp_default_date'          => '',
             'dp_disabled_dates'        => array(),
             'dp_enabled_dates'         => array(),

--- a/Resources/config/form_types.xml
+++ b/Resources/config/form_types.xml
@@ -38,12 +38,14 @@
             <tag name="form.type" alias="sonata_type_date_picker" />
 
             <argument type="service" id="sonata.core.date.moment_format_converter" />
+            <argument type="service" id="translator" />
         </service>
 
         <service id="sonata.core.form.type.datetime_picker" class="Sonata\CoreBundle\Form\Type\DateTimePickerType">
             <tag name="form.type" alias="sonata_type_datetime_picker" />
 
             <argument type="service" id="sonata.core.date.moment_format_converter" />
+            <argument type="service" id="translator" />
         </service>
 
         <service id="sonata.core.form.type.date_range_picker" class="Sonata\CoreBundle\Form\Type\DateRangePickerType">

--- a/Tests/Form/Type/BasePickerTypeTest.php
+++ b/Tests/Form/Type/BasePickerTypeTest.php
@@ -40,7 +40,7 @@ class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testFinishView()
     {
-        $type = new BasePickerTest(new MomentFormatConverter());
+        $type = new BasePickerTest(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $view = new FormView();
         $form = new Form($this->getMock('Symfony\Component\Form\FormConfigInterface'));
@@ -57,5 +57,10 @@ class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals('text', $view->vars['type']);
+    }
+
+    public function testLegacyConstructor()
+    {
+        new BasePickerTest(new MomentFormatConverter());
     }
 }

--- a/Tests/Form/Type/DatePickerTypeTest.php
+++ b/Tests/Form/Type/DatePickerTypeTest.php
@@ -24,6 +24,13 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetName()
     {
+        $type = new DatePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        $this->assertEquals('sonata_type_date_picker', $type->getName());
+    }
+
+    public function testLegacyConstructor()
+    {
         $type = new DatePickerType(new MomentFormatConverter());
 
         $this->assertEquals('sonata_type_date_picker', $type->getName());

--- a/Tests/Form/Type/DateTimePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimePickerTypeTest.php
@@ -24,6 +24,13 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetName()
     {
+        $type = new DateTimePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        $this->assertEquals('sonata_type_datetime_picker', $type->getName());
+    }
+
+    public function testLegacyConstructor()
+    {
         $type = new DateTimePickerType(new MomentFormatConverter());
 
         $this->assertEquals('sonata_type_datetime_picker', $type->getName());


### PR DESCRIPTION
The actual datepicker and datetimepicker is using "\Locale::getDefault()" which is always returning "en".
So, the html view of the calendar is always in english, even if the default_locale is not english.
Now, the datepicker (js options) is using the real default locale.