### PR TITLE
Add Twig extensions as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/validator": "~2.3",
         "symfony/property-access": "~2.3",
         "twig/twig": "~1.16",
+        "twig/extensions": "~1.0",
         "cocur/slugify": "*"
     },
     "require-dev": {


### PR DESCRIPTION
As of 2.7 and https://github.com/symfony/symfony-standard/commit/1272c9fff1c6622c683553b545736eda36914e5a, Symfony does not include by default the twig extensions.

But SonataCoreBundle need them (https://github.com/sonata-project/SonataCoreBundle/blob/master/Resources/config/twig.xml#L12) so I added the Twig extensions as a dependency. 