### PR TITLE
Rollback catalogue option name

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -50,7 +50,7 @@ class BooleanType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'translation_domain' => 'SonataCoreBundle',
+            'catalogue' => 'SonataCoreBundle',
             'choices'            => array(
                 self::TYPE_YES  => 'label_type_yes',
                 self::TYPE_NO   => 'label_type_no',


### PR DESCRIPTION
As the form type use SonataTranslatableChoiceType as parent the translation catalog parameter must be catalogue and not translation_domain