### PR TITLE
Use choice instead of deprecated sonata_type_translatable_choice in BooleanType

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -64,7 +64,7 @@ class BooleanType extends AbstractType
      */
     public function getParent()
     {
-        return 'sonata_type_translatable_choice';
+        return 'choice';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #187
| License       | MIT