### PR TITLE
Trigger E_USER_DEPRECATED error when using the TranslatableChoiceType.

### DIFF
--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -7,8 +7,6 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @deprecated - use ChoiceType with the translation_domain option instead
  */
 
 namespace Sonata\CoreBundle\Form\Type;
@@ -20,6 +18,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * @deprecated Deprecated as of SonataCoreBundle 2.2.0, to be removed in 3.0. Use form type "choice" with "translation_domain" option instead.
+ */
 class TranslatableChoiceType extends AbstractType
 {
     protected $translator;
@@ -29,6 +30,8 @@ class TranslatableChoiceType extends AbstractType
      */
     public function __construct(TranslatorInterface $translator)
     {
+        @trigger_error('Form type "sonata_type_translatable_choice" is deprecated since SonataCoreBundle 2.2.0 and will be removed in 3.0. Use form type "choice" with "translation_domain" option instead.', E_USER_DEPRECATED);
+
         $this->translator = $translator;
     }
 

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -96,7 +96,7 @@ sonata_type_translatable_choice
 
 .. warning::
 
-    ``sonata_type_translatable_choice`` is deprecated,  use ``ChoiceType`` with the ``translation_domain`` option instead!
+    ``sonata_type_translatable_choice`` is deprecated and will be removed in 3.0. Use form type ``choice`` with ``translation_domain`` option instead!
 
 The translatable type is a specialized ``ChoiceType`` where the choices values are translated with the Symfony Translator component.
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,41 @@
+UPGRADE FROM 2.X to 3.0
+=======================
+
+### TranslatableChoiceType was removed
+
+Form type "sonata_type_translatable_choice" (TranslatableChoiceType) was removed. Use form type "choice" (ChoiceType) with "translation_domain" option instead.
+
+Before:
+
+```php
+class FooAdmin extends Admin
+{
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper->add('articleAuthor', 'sonata_type_translatable_choice',
+            array(
+                'catalogue'=>'FooAdminBundle',
+                'choices'=>array(0=>'no', 1=>'yes')
+            )
+        );
+    }
+}
+```
+
+After:
+
+```php
+class FooAdmin extends Admin
+{
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper->add('articleAuthor', 'choice',
+            array(
+                'translation_domain'=>'FooAdminBundle',
+                'choices'=>array(0=>'no', 1=>'yes')
+            )
+        );
+    }
+}
+```
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT