### PR TITLE
fixed missing annotation and target annotation

### DIFF
--- a/Validator/Constraints/InlineConstraint.php
+++ b/Validator/Constraints/InlineConstraint.php
@@ -13,6 +13,12 @@ namespace Sonata\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * Constraint which allows inline-validation inside services.
+ * 
+ * @Annotation
+ * @Target({"CLASS"})
+ */
 class InlineConstraint extends Constraint
 {
     protected $service;


### PR DESCRIPTION
these annotations are mandatory when using this constraint as annotation on objects.