### PR TITLE
Set specific cocur/slugify version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/validator": "~2.3",
         "symfony/property-access": "~2.3",
         "twig/twig": "~1.16",
-        "cocur/slugify": "*"
+        "cocur/slugify": "~1.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "~0.4",


### PR DESCRIPTION
We will be releasing Version 2.0 of [cocur/slugify](https://github.com/cocur/slugify) in the next few months and since it might break compatibility I suggest setting a more strict version constraint (e.g., `~1.4` for the package.