### PR TITLE
[FIX] Doc

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -315,7 +315,7 @@ In your layout, you'll need to add the assets dependencies (feel free to adapt t
     <head>
         <!-- ... -->
         <script type="text/javascript" src="path_to_jquery.min.js"></script>
-        <script type="text/javascript" src="/bundles/sonatacore/vendor/moment/min/moment.min.js"></script>
+        <script type="text/javascript" src="/bundles/sonatacore/vendor/moment/min/moment-with-locales.min.js"></script>
         <script type="text/javascript" src="path_to_bootstrap.min.js"></script>
         <script type="text/javascript" src="/bundles/sonatacore/vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
         <link rel="stylesheet" href="path_to_bootstrap.min.css" />


### PR DESCRIPTION
The problem occurs when the form type is used without the locale.
`Moment.js` library is able to manage the current locale but without them the `sonata_type_datetime_picker` field is bugged.