### PR TITLE
prepend config no matter how things are organised

### DIFF
--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -34,11 +34,13 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
     {
         $configs = $container->getExtensionConfig('sonata_admin');
 
-        if (isset($configs[0]['options']['form_type'])) {
-            $container->prependExtensionConfig(
-                $this->getAlias(),
-                array('form_type' => $configs[0]['options']['form_type'])
-            );
+        foreach ($configs as $config) {
+            if (isset($config['options']['form_type'])) {
+                $container->prependExtensionConfig(
+                    $this->getAlias(),
+                    array('form_type' => $config['options']['form_type'])
+                );
+            }
         }
     }
 

--- a/Tests/DependencyInjection/SonataCoreExtensionTest.php
+++ b/Tests/DependencyInjection/SonataCoreExtensionTest.php
@@ -50,4 +50,30 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
             )
         );
     }
+
+    public function testPrepend()
+    {
+        $containerBuilder = $this->prophesize(
+            'Symfony\Component\DependencyInjection\ContainerBuilder'
+        );
+
+        $containerBuilder->getExtensionConfig('sonata_admin')->willReturn(array(
+            array('some_key_we_do_not_care_about' => 42),
+            array('options' => array('form_type' => 'standard')),
+            array('options' => array('form_type' => 'horizontal')),
+        ));
+
+        $containerBuilder->prependExtensionConfig(
+            'sonata_core',
+            array('form_type' => 'standard')
+        )->shouldBeCalled();
+
+        $containerBuilder->prependExtensionConfig(
+            'sonata_core',
+            array('form_type' => 'horizontal')
+        )->shouldBeCalled();
+
+        $extension = new SonataCoreExtension();
+        $extension->prepend($containerBuilder->reveal());
+    }
 }


### PR DESCRIPTION
Mea culpa : I did not understand why there were several config blocks
when writing this piece of code, but now it is clear : in my
application, I am the configuring sonata admin security part in
security.yml, and the other parts in config.yml . The part in security
is the first config block, but it does not contain the options key (the
part in config.yml does). This change will prepend the config as soon as
the requested config key is detected, no matter whether the
configuration is split or not. If this key appears twice in different
config blocks, the last occurrence will have its value taken into
account.