### PR TITLE
#issue choice options in advanced filters are flipped [sf3]

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -55,11 +55,17 @@ class BooleanType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $choices =  array(
+            self::TYPE_YES => 'label_type_yes',
+            self::TYPE_NO  => 'label_type_no',
+        );
+
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $resolver->setDefaults(array(
-            'choices'            => array(
-                self::TYPE_YES  => 'label_type_yes',
-                self::TYPE_NO   => 'label_type_no',
-            ),
+            'choices'   => $choices,
             'transform' => false,
 
             // @deprecated Deprecated as of SonataCoreBundle 2.3.10, to be removed in 3.0.

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -51,11 +51,17 @@ class EqualType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $choices = array(
+            self::TYPE_IS_EQUAL     => $this->translator->trans('label_type_equals', array(), 'SonataCoreBundle'),
+            self::TYPE_IS_NOT_EQUAL => $this->translator->trans('label_type_not_equals', array(), 'SonataCoreBundle'),
+        );
+
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $resolver->setDefaults(array(
-            'choices' => array(
-                self::TYPE_IS_EQUAL     => $this->translator->trans('label_type_equals', array(), 'SonataCoreBundle'),
-                self::TYPE_IS_NOT_EQUAL => $this->translator->trans('label_type_not_equals', array(), 'SonataCoreBundle'),
-            ),
+            'choices' => $choices,
         ));
     }
 

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -20,7 +20,14 @@ class EqualTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions()
     {
-        $type = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $mock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+
+        $mock->expects($this->exactly(2))
+            ->method('trans')
+            ->will($this->returnCallback(function ($arg) { return $arg; })
+            );
+
+        $type = new EqualType($mock);
 
         $this->assertEquals('sonata_type_equal', $type->getName());
         $this->assertEquals('choice', $type->getParent());
@@ -29,8 +36,14 @@ class EqualTypeTest extends TypeTestCase
 
         $options = $resolver->resolve();
 
+        $choices = array(1 => 'label_type_equals', 2 => 'label_type_not_equals');
+
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
         $expected = array(
-            'choices' => array(1 => null, 2 => null),
+            'choices' => $choices,
         );
 
         $this->assertEquals($expected, $options);


### PR DESCRIPTION
Related to [ sonata-project/SonataAdminBundle@PR #3585](https://github.com/sonata-project/SonataAdminBundle/pull/3585)

Symfony 3.* remove choices_as_value = false 

> symfony/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php

```php
if (true !== $choicesAsValues) {
    throw new \RuntimeException(sprintf('The "choices_as_values" option of the %s should not be used. Remove it and flip the contents of the "choices" option instead.', get_class($this)));
}
```

[source code](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L269)