### PR TITLE
Modifications in the convert function of the MomentFormatConverter class

### DIFF
--- a/Tests/Date/MomentFormatConverterTest.php
+++ b/Tests/Date/MomentFormatConverterTest.php
@@ -78,5 +78,8 @@ class MomentFormatConverterTest extends \PHPUnit_Framework_TestCase
 
         $phpFormat = 'D MMM y';
         $this->assertEquals('D MMM YYYY', $mfc->convert($phpFormat));
+
+        $phpFormat = "dd 'de' MMMM 'de' YYYY"; //Brazilian date format
+        $this->assertEquals('DD [de] MMMM [de] YYYY', $mfc->convert($phpFormat));
     }
 }


### PR DESCRIPTION
As debated in this [issue](https://github.com/sonata-project/SonataAdminBundle/issues/3643). I've changed the convert function of the MomentFormatConverter class, since there was a problem with the output in case of pt_BR locale. I also added a assertion in the MomentFormartConvertTest class, to test the problem. 