### PR TITLE
Travis: Cleanup configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - hhvm
+  - nightly
 
 sudo: false
 
@@ -17,42 +13,50 @@ cache:
 
 env:
   global:
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
     - SYMFONY_DEPRECATIONS_HELPER=weak
+    - TARGET=test
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: CS_FIXER=run
+    - php: 7.0
+      env: TARGET=cs_dry_run
+    - php: 7.0
+      env: TARGET=docs
     - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.6.*
-    - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.5
+      env: SYMFONY_VERSION=3.0.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.x-dev" DEPENDENCIES="dev" COMPOSER_FLAGS="--prefer-stable"
+      env: SYMFONY_VERSION=3.0.*
     - php: 7.0
+      env: SYMFONY_VERSION=3.0.*
+
+  allow_failures:
     - php: hhvm
+    - php: nightly
 
 before_script:
+  - (phpenv config-rm xdebug.ini || exit 0)
   - mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d && echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer selfupdate
-  - composer config -q github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.x-dev" ]; then SYMFONY_DEPRECATIONS_HELPER=strict; fi;
+  - composer config -q -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
+  - composer global require phpunit/phpunit:@stable fabpot/php-cs-fixer --no-update
+  - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r Resources/doc/requirements.txt --user `whoami`
 
 script:
- - if [ "$CS_FIXER" = "run" ]; then make cs_dry_run ; fi;
- - make test
+ - make $TARGET
 
 notifications:
   webhooks: https://sonata-project.org/bundles/core/master/travis

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-.PHONY: test
-
 cs:
-	./vendor/bin/php-cs-fixer fix --verbose
+	php-cs-fixer fix --verbose
 
 cs_dry_run:
-	./vendor/bin/php-cs-fixer fix --verbose --dry-run
+	php-cs-fixer fix --verbose --dry-run
 
 test:
 	phpunit
+
+docs:
 	cd Resources/doc && sphinx-build -W -b html -d _build/doctrees . _build/html
+
 bower:
 	bower update

--- a/Tests/Validator/ErrorElementTest.php
+++ b/Tests/Validator/ErrorElementTest.php
@@ -177,10 +177,19 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new NotNull();
 
-        $this->context->expects($this->any())
-            ->method('validateValue')
-            ->with($this->equalTo($this->subject), $this->equalTo($constraint), $this->equalTo(''), $this->equalTo('foo_core'))
-            ->will($this->returnValue(null));
+        if ($this->context instanceof LegacyExecutionContextInterface) {
+            $this->context->expects($this->any())
+                ->method('validateValue')
+                ->with($this->equalTo($this->subject), $this->equalTo($constraint), $this->equalTo(''), $this->equalTo('foo_core'))
+                ->will($this->returnValue(null));
+        } else {
+            $this->contextualValidator->expects($this->any())
+                ->method('atPath')
+                ->with('');
+            $this->contextualValidator->expects($this->any())
+                ->method('validate')
+                ->with($this->subject, $constraint, array('foo_core'));
+        }
 
         $this->assertEquals($this->errorElement, $this->errorElement->with('baz'));
         $this->assertEquals($this->errorElement, $this->errorElement->end());


### PR DESCRIPTION
- cleanup old symfony 2.8 and 3.0 hacks
- moved **php-cs-fixer** to travis
- **php-cs-fixers** runs once under PHP7
- **sphinx-build** runs once under PHP7
- added PHP nightly builds

See: https://github.com/sonata-project/SonataAdminBundle/pull/3584