### PR TITLE
Fix deprecation notices on getParent

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -81,7 +81,9 @@ class BooleanType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\ChoiceType') ?
+        'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
+
     }
 
     /**

--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -57,7 +57,8 @@ class ColorSelectorType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\ChoiceType') ?
+        'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -49,7 +49,8 @@ class DatePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return 'date';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\DateType') ?
+        'Symfony\Component\Form\Extension\Core\Type\DateType' : 'date';
     }
 
     /**

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -52,7 +52,8 @@ class DateTimePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return 'datetime';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\DateTimeType') ?
+        'Symfony\Component\Form\Extension\Core\Type\DateTimeType' : 'datetime';
     }
 
     /**

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -64,7 +64,8 @@ class EqualType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\ChoiceType') ?
+        'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
     }
 
     /**

--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -71,7 +71,8 @@ class TranslatableChoiceType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return class_exists('Symfony\Component\Form\Extension\Core\Type\ChoiceType') ?
+        'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice';
     }
 
     /**


### PR DESCRIPTION
This should fix all deprecation notices when getForm is invoked but it should be reviewed as I do not know much about GitHub and contributing to repos.