### PR TITLE
Return FQCN for SF2.8+ and text type for >2.8

### DIFF
--- a/Form/FormHelper.php
+++ b/Form/FormHelper.php
@@ -95,7 +95,7 @@ class FormHelper
     {
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $type->setDefaultOptions($optionsResolver);
-        } else {
+        } else { // SF <2.8 BC
             $type->configureOptions($optionsResolver);
         }
     }

--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -81,7 +81,9 @@ class BooleanType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+            'choice';
     }
 
     /**

--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -83,7 +83,8 @@ class BooleanType extends AbstractType
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
             'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+            'choice' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -57,7 +57,9 @@ class ColorSelectorType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+            'choice';
     }
 
     /**

--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -59,7 +59,8 @@ class ColorSelectorType extends AbstractType
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
             'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+            'choice' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -49,7 +49,9 @@ class DatePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return 'date';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+           'Symfony\Component\Form\Extension\Core\Type\DateType' :
+           'date';
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -51,7 +51,8 @@ class DatePickerType extends BasePickerType
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
            'Symfony\Component\Form\Extension\Core\Type\DateType' :
-           'date';
+           'date' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -53,8 +53,9 @@ class DateTimePickerType extends BasePickerType
     public function getParent()
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-+           'Symfony\Component\Form\Extension\Core\Type\DateTimeType' :
-+           'datetime';
+            'Symfony\Component\Form\Extension\Core\Type\DateTimeType' :
+            'datetime' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -52,7 +52,9 @@ class DateTimePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return 'datetime';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
++           'Symfony\Component\Form\Extension\Core\Type\DateTimeType' :
++           'datetime';
     }
 
     /**

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -66,7 +66,8 @@ class EqualType extends AbstractType
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
             'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+            'choice' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -64,7 +64,9 @@ class EqualType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+            'choice';
     }
 
     /**

--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -73,7 +73,8 @@ class TranslatableChoiceType extends AbstractType
     {
         return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
             'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+            'choice' // SF <2.8 BC
+        ;
     }
 
     /**

--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -71,7 +71,9 @@ class TranslatableChoiceType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+            'choice';
     }
 
     /**

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -22,7 +22,12 @@ class BooleanTypeTest extends TypeTestCase
     {
         $type = new BooleanType();
 
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals(
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+                'choice',
+            $type->getParent()
+        );
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -23,7 +23,12 @@ class ColorSelectorTypeTest extends TypeTestCase
         $type = new ColorSelectorType();
 
         $this->assertEquals('sonata_type_color_selector', $type->getName());
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals(
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+                'choice',
+            $type->getParent()
+        );
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -23,7 +23,12 @@ class EqualTypeTest extends TypeTestCase
         $type = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertEquals('sonata_type_equal', $type->getName());
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals(
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+                'choice',
+            $type->getParent()
+        );
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/Tests/Form/Type/TranslatableChoiceTypeTest.php
+++ b/Tests/Form/Type/TranslatableChoiceTypeTest.php
@@ -26,7 +26,12 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals(
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+                'choice',
+            $type->getParent()
+        );
 
         $options = $resolver->resolve(array('catalogue' => 'foo'));
 


### PR DESCRIPTION
Closes #235.

Returns fuly qualified class name for the parent in case Symfony 2.8+is
used or text for versions below 2.8