### PR TITLE
Support form types that don't have a service

### DIFF
--- a/Form/Extension/DependencyInjectionExtension.php
+++ b/Form/Extension/DependencyInjectionExtension.php
@@ -90,7 +90,11 @@ class DependencyInjectionExtension implements FormExtensionInterface
         $name = self::findClass($this->mappingTypes, $name);
 
         if (!isset($this->typeServiceIds[$name])) {
-            throw new InvalidArgumentException(sprintf('The field type "%s" is not registered with the service container.', $name));
+            if (class_exists($name) && in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name), true)) {
+                return new $name();
+            } else {
+                throw new InvalidArgumentException(sprintf('The field type "%s" is not registered with the service container.', $name));
+            }
         }
 
         $type = $this->container->get($this->typeServiceIds[$name]);

--- a/Tests/Form/Extension/DependencyInjectionExtensionTest.php
+++ b/Tests/Form/Extension/DependencyInjectionExtensionTest.php
@@ -50,6 +50,15 @@ class DependencyInjectionExtensionTest extends \PHPUnit_Framework_TestCase
         $f->getType('Symfony\Component\Form\Type\FormType');
     }
 
+    public function testTypeWithoutService()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $f = new DependencyInjectionExtension($container, array(), array(), array(), array());
+
+        $this->assertInstanceOf('Symfony\Component\Form\Extension\Core\Type\HiddenType', $f->getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'));
+    }
+
     public function testTypeExtensionsValid()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');


### PR DESCRIPTION
Form types don't have to have a corresponding service tagged as form.type. If they have no dependencies, the FQCN can be instantiated directly.

This is especially important as most core form types are no longer registered as services since Symfony 3.1. Currently, Sonata does not work on Symfony 3.1 because of this.

Btw, I think it would make more sense if this BC layer works the other way around: Using the form name instead of FQCN in Symfony <2.8. This makes the changes required when dropping Symfony <2.8 support way less and makes things as this much easier to handle (as we could just return false from `hasType()` and the FormRegistry would take care of instantiating the class). However, if wanted, let's do that in another PR.