### PR TITLE
Inject writers in the exporter.

### DIFF
--- a/DependencyInjection/Compiler/ExporterCompilerPass.php
+++ b/DependencyInjection/Compiler/ExporterCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class ExporterCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('sonata.core.exporter')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('sonata.core.exporter');
+        $writers = $container->findTaggedServiceIds('sonata.core.exporter.writer');
+
+        foreach (array_keys($writers) as $id) {
+            $definition->addMethodCall(
+                'addWriter',
+                array(new Reference($id))
+            );
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,15 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->arrayNode('exporter')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('default_writers')
+                            ->defaultValue(array('csv', 'json', 'xls', 'xml'))
+                            ->prototype('scalar')->end()
+                        ->end()
+                    ->end()
+                ->end()
                 ->arrayNode('form')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -62,7 +62,9 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('twig.xml');
         $loader->load('model_adapter.xml');
         $loader->load('core.xml');
+        $loader->load('exporter.xml');
 
+        $this->configureExporter($container, $config);
         $this->registerFlashTypes($container, $config);
         $container->setParameter('sonata.core.form_type', $config['form_type']);
 
@@ -172,6 +174,17 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
 
             $definition = $container->getDefinition('sonata.core.slugify.native');
             $definition->setDeprecated(true);
+        }
+    }
+
+    private function configureExporter(ContainerBuilder $container, array $config)
+    {
+        foreach (array('csv', 'json', 'xls', 'xml') as $format) {
+            if (in_array($format, $config['exporter']['default_writers'])) {
+                $container->getDefinition('sonata.core.exporter.writer.'.$format)->addTag(
+                    'sonata.core.exporter.writer'
+                );
+            }
         }
     }
 }

--- a/Resources/config/exporter.xml
+++ b/Resources/config/exporter.xml
@@ -1,6 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sonata.core.exporter.writer.csv.filename">php://output</parameter>
+        <parameter key="sonata.core.exporter.writer.csv.delimiter">,</parameter>
+        <parameter key="sonata.core.exporter.writer.csv.enclosure">"</parameter>
+        <parameter key="sonata.core.exporter.writer.csv.escape">\</parameter>
+        <parameter key="sonata.core.exporter.writer.csv.show_headers">true</parameter>
+        <parameter key="sonata.core.exporter.writer.csv.with_bom">false</parameter>
+        <parameter key="sonata.core.exporter.writer.json.filename">php://output</parameter>
+        <parameter key="sonata.core.exporter.writer.xls.filename">php://output</parameter>
+        <parameter key="sonata.core.exporter.writer.xls.show_headers">true</parameter>
+        <parameter key="sonata.core.exporter.writer.xml.filename">php://output</parameter>
+        <parameter key="sonata.core.exporter.writer.xml.main_element">datas</parameter>
+        <parameter key="sonata.core.exporter.writer.xml.child_element">data</parameter>
+    </parameters>
     <services>
-        <service id="sonata.core.exporter" class="Sonata\CoreBundle\Exporter\Exporter"/>
+        <service id="sonata.core.exporter.writer.csv" class="Exporter\Writer\CsvWriter" public="false">
+            <argument>%sonata.core.exporter.writer.csv.filename%</argument>
+            <argument>%sonata.core.exporter.writer.csv.delimiter%</argument>
+            <argument>%sonata.core.exporter.writer.csv.enclosure%</argument>
+            <argument>%sonata.core.exporter.writer.csv.escape%</argument>
+            <argument>%sonata.core.exporter.writer.csv.show_headers%</argument>
+            <argument>%sonata.core.exporter.writer.csv.with_bom%</argument>
+        </service>
+        <service id="sonata.core.exporter.writer.json" class="Exporter\Writer\JsonWriter" public="false">
+            <argument>%sonata.core.exporter.writer.json.filename%</argument>
+        </service>
+        <service id="sonata.core.exporter.writer.xls" class="Exporter\Writer\XlsWriter" public="false">
+            <argument>%sonata.core.exporter.writer.xls.filename%</argument>
+            <argument>%sonata.core.exporter.writer.xls.show_headers%</argument>
+        </service>
+        <service id="sonata.core.exporter.writer.xml" class="Exporter\Writer\XmlWriter" public="false">
+            <argument>%sonata.core.exporter.writer.xml.filename%</argument>
+            <argument>%sonata.core.exporter.writer.xml.main_element%</argument>
+            <argument>%sonata.core.exporter.writer.xml.child_element%</argument>
+        </service>
+        <service id="sonata.core.exporter" class="Sonata\CoreBundle\Exporter\Exporter">
+            <argument type="collection"/>
+            <!-- NEXT_MAJOR : remove this argument -->
+        </service>
     </services>
 </container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -21,4 +21,5 @@ Reference Guide
    reference/api
    reference/conditional_validation
    reference/command
+   reference/exporter
 

--- a/Resources/doc/reference/exporter.rst
+++ b/Resources/doc/reference/exporter.rst
@@ -1,0 +1,85 @@
+The exporter
+============
+
+This bundle provides a ``sonata.core.exporter`` service that integrates ``sonata-project/exporter`` with Symfony
+by building a streamed response directly usable in a Symfony controller from a format, a filename, and a source.
+
+.. code-block:: php
+
+    <?php
+    namespace MyCompany\MyProject\Controller;
+
+    class WhateverController
+    {
+        public function myExportAction()
+        {
+            // build $source, which must be an Exporter\Source\SourceIteratorInterface implementation
+            return $this->get('sonata.core.exporter')->getResponse(
+                'csv', // possible values are csv, json, xls, and xml
+                '/tmp/myFile.csv',
+                $source
+            );
+        }
+    }
+
+The default writers
+-------------------
+
+Under the hood, the exporter one service for each available format.
+Each service has its own parameters, documented below.
+
+The CSV writer service
+~~~~~~~~~~~~~~~~~~~~~~
+This service can be configured throught the following parameters:
+
+* ``sonata.core.exporter.writer.csv.filename``: defaults to ``php://output``
+* ``sonata.core.exporter.writer.csv.delimiter``: defaults to ``,``
+* ``sonata.core.exporter.writer.csv.enclosure``: defaults to ``"``
+* ``sonata.core.exporter.writer.csv.escape``: defaults to ``\\``
+* ``sonata.core.exporter.writer.csv.show_headers``: defaults to ``true``
+* ``sonata.core.exporter.writer.csv.with_bom``: defaults to ``false``
+
+The Json writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Only the filename may be configured for this service:
+``sonata.core.exporter.writer.json.filename``: defaults to ``php://output``
+
+The Xls writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This service can be configured throught the following parameters:
+
+* ``sonata.core.exporter.writer.xls.filename``: defaults to ``php://output``
+* ``sonata.core.exporter.writer.xls.show_headers``: defaults to ``true``
+
+The Xml writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This service can be configured throught the following parameters:
+
+* ``sonata.core.exporter.writer.xml.filename``: defaults to ``php://output``
+* ``sonata.core.exporter.writer.xml.show_headers``: defaults to ``true``
+* ``sonata.core.exporter.writer.xml.main_element``: defaults to ``datas``
+* ``sonata.core.exporter.writer.xml.child_element``: defaults to ``data``
+
+Adding a custom writer to the list
+----------------------------------
+
+If you want to add a custom writer to the list of writers supported by the exporter,
+you simply need to tag your service,
+which must implement ``Exporter\Writer\TypedWriterInterface``,
+with the ``sonata.core.exporter.writer`` tag.
+
+Configuring the default writers
+-------------------------------
+
+The default writers list can be altered through configuration:
+
+.. code-block:: yaml
+
+    sonata_core:
+        exporter:
+            default_writers:
+                - csv
+                - json

--- a/SonataCoreBundle.php
+++ b/SonataCoreBundle.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle;
 
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
+use Sonata\CoreBundle\DependencyInjection\Compiler\ExporterCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
@@ -28,6 +29,7 @@ class SonataCoreBundle extends Bundle
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
         $container->addCompilerPass(new FormFactoryCompilerPass());
+        $container->addCompilerPass(new ExporterCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/Tests/DependencyInjection/Compiler/ExporterCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ExporterCompilerPassTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\CoreBundle\DependencyInjection\Compiler\ExporterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ExporterCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testWritersAreAddedToTheExporter()
+    {
+        $exporter = new Definition();
+        $this->setDefinition('sonata.core.exporter', $exporter);
+
+        $writer = new Definition();
+        $writer->addTag('sonata.core.exporter.writer');
+        $this->setDefinition('foo_writer', $writer);
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.core.exporter',
+            'addWriter',
+            array(
+                new Reference('foo_writer'),
+            )
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ExporterCompilerPass());
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -39,6 +39,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
         ), array(
             'form_type' => 'standard',
             'flashmessage' => array(),
+            'exporter' => array('default_writers' => array(
+                'csv', 'json', 'xls', 'xml',
+            )),
             'form' => array(
                 'mapping' => array(
                     'enabled' => true,
@@ -81,6 +84,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
                     ),
                 ),
             ),
+            'exporter' => array('default_writers' => array(
+                'csv', 'json', 'xls', 'xml',
+            )),
             'form_type' => 'standard',
             'flashmessage' => array(),
             'serializer' => array(
@@ -101,6 +107,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
                     'extension' => array(),
                 ),
             ),
+            'exporter' => array('default_writers' => array(
+                'csv', 'json', 'xls', 'xml',
+            )),
             'form_type' => 'standard',
             'flashmessage' => array(),
             'serializer' => array(

--- a/Tests/DependencyInjection/SonataCoreExtensionTest.php
+++ b/Tests/DependencyInjection/SonataCoreExtensionTest.php
@@ -70,6 +70,12 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
         $extension->prepend($containerBuilder->reveal());
     }
 
+    public function testExporterServiceIsPresent()
+    {
+        $this->load();
+        $this->assertContainerBuilderHasService('sonata.core.exporter');
+    }
+
     protected function getContainerExtensions()
     {
         return array(

--- a/Tests/Exporter/ExporterTest.php
+++ b/Tests/Exporter/ExporterTest.php
@@ -12,19 +12,62 @@
 namespace Sonata\CoreBundle\Tests\Exporter;
 
 use Exporter\Source\ArraySourceIterator;
+use Exporter\Writer\CsvWriter;
+use Exporter\Writer\JsonWriter;
+use Exporter\Writer\XlsWriter;
+use Exporter\Writer\XmlWriter;
 use Sonata\CoreBundle\Exporter\Exporter;
 
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     */
     public function testFilter()
     {
+        $this->setExpectedException('RuntimeException', 'Invalid "foo" format');
         $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+
+        $exporter = new Exporter(array($writer));
+        $exporter->getResponse('foo', 'foo', $source);
+    }
+
+    public function testConstructorRejectsNonTypedWriters()
+    {
+        $this->setExpectedException(
+            version_compare(PHP_VERSION, '7.0.0', '<') ? 'PHPUnit_Framework_Error' : 'TypeError',
+            'must implement interface'
+        );
+        new Exporter(array('Not even an object'));
+    }
+
+    /**
+     * NEXT_MAJOR: remove this test.
+     *
+     * @dataProvider getResponseLegacyTests
+     * @group legacy
+     */
+    public function testConstructorCreatesDefaultWritersOnLegacyCall($format, $filename, $contentType)
+    {
+        $source = new ArraySourceIterator(array(
+            array('foo' => 'bar'),
+        ));
 
         $exporter = new Exporter();
-        $exporter->getResponse('foo', 'foo', $source);
+        $response = $exporter->getResponse($format, $filename, $source);
+
+        $this->assertSame($contentType, $response->headers->get('Content-Type'));
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
+    public function getResponseLegacyTests()
+    {
+        return array(
+            array('json', 'foo.json', 'application/json'),
+            array('xml', 'foo.xml', 'text/xml'),
+            array('xls', 'foo.xls', 'application/vnd.ms-excel'),
+            array('csv', 'foo.csv', 'text/csv'),
+        );
     }
 
     /**
@@ -35,8 +78,21 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
         $source = new ArraySourceIterator(array(
             array('foo' => 'bar'),
         ));
+        $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+        $writer->expects($this->any())
+            ->method('getFormat')
+            ->willReturn('made-up');
+        $writer->expects($this->any())
+            ->method('getDefaultMimeType')
+            ->willReturn('application/made-up');
 
-        $exporter = new Exporter();
+        $exporter = new Exporter(array(
+            'csv' => new CsvWriter('php://output', ',', '"', '', true, true),
+            'json' => new JsonWriter('php://output'),
+            'xls' => new XlsWriter('php://output'),
+            'xml' => new XmlWriter('php://output'),
+            'made-up' => $writer,
+        ));
         $response = $exporter->getResponse($format, $filename, $source);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
@@ -51,6 +107,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
             array('xml', 'foo.xml', 'text/xml'),
             array('xls', 'foo.xls', 'application/vnd.ms-excel'),
             array('csv', 'foo.csv', 'text/csv'),
+            array('made-up', 'foo.made-up', 'application/made-up'),
         );
     }
 }

--- a/Tests/SonataCoreBundleTest.php
+++ b/Tests/SonataCoreBundleTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Tests;
 
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
+use Sonata\CoreBundle\DependencyInjection\Compiler\ExporterCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
@@ -30,7 +31,7 @@ final class SonataCoreBundleTest extends \PHPUnit_Framework_TestCase
             array('addCompilerPass')
         );
 
-        $containerBuilder->expects($this->exactly(3))
+        $containerBuilder->expects($this->exactly(4))
             ->method('addCompilerPass')
             ->will($this->returnCallback(function (CompilerPassInterface $pass) {
                 if ($pass instanceof StatusRendererCompilerPass) {
@@ -41,14 +42,19 @@ final class SonataCoreBundleTest extends \PHPUnit_Framework_TestCase
                     return;
                 }
 
+                if ($pass instanceof ExporterCompilerPass) {
+                    return;
+                }
+
                 if ($pass instanceof FormFactoryCompilerPass) {
                     return;
                 }
 
                 $this->fail(sprintf(
-                    'Compiler pass is not one of the expected types. 
-                    Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass", 
-                    "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass" or 
+                    'Compiler pass is not one of the expected types.
+                    Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass",
+                    "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass" or
+                    "Sonata\AdminBundle\DependencyInjection\Compiler\ExporterCompilerPass" or
                     "Sonata\AdminBundle\DependencyInjection\Compiler\FormFactoryCompilerPass", but got "%s".',
                     get_class($pass)
                 ));

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "nelmio/api-doc-bundle": "^2.11",
         "sensio/framework-extra-bundle": "^2.3 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/exporter": "^1.3",
+        "sonata-project/exporter": "^1.5",
         "symfony/phpunit-bridge": "^2.7"
     },
     "autoload": {


### PR DESCRIPTION
Closes #269 

### Changelog

```markdown
### Added
- `Sonata\CoreBundle\Exporter\Exporter::__construct()` now accepts a hash of writers.
- `Sonata\CoreBundle\Exporter\Exporter::__addWriter()` allows to add writers through the new `sonata_core.exporter.writer` tag.
- Existing exporter writers can be configured with container parameters.
```

### Todo

- [x] test the service definitions
- [x] document the new service
- [x] introduce container parameters to make the default services configurable
- [x] find a way to let people add new writers
- [x] find a way to let people pick and choose default writers

### Subject

Being able to inject any writer means being able to inject custom writers, but also configure existing writers otherwise. Both are interesting.
