### PR TITLE
Fix typo on choices_as_values option for EqualType

### DIFF
--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -63,7 +63,7 @@ class EqualType extends AbstractType
 
             // choice_as_value options is not needed in SF 3.0+
             if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_value'] = true;
+                $defaultOptions['choices_as_values'] = true;
             }
         }
 

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -50,13 +50,13 @@ class EqualTypeTest extends TypeTestCase
         }
 
         $expected = array(
-            'choices_as_value' => true,
+            'choices_as_values' => true,
             'choices' => $choices,
         );
 
         if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')
             || !method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            unset($expected['choices_as_value']);
+            unset($expected['choices_as_values']);
         }
 
         $this->assertSame($expected, $options);


### PR DESCRIPTION
### Changelog

fix typo in form type option

```markdown
### Fixed
- Typo on `choices_as_values` option for `EqualType`
```

### Subject

in respect of SF type form, the value for `choices_as_values` have to be ends with an "s"

