### PR TITLE
fix typo

### DIFF
--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -63,7 +63,7 @@ class EqualType extends AbstractType
 
             // choice_as_value options is not needed in SF 3.0+
             if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_value'] = true;
+                $defaultOptions['choices_as_values'] = true;
             }
         }
 


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

fix typo in class `\Sonata\CoreBundle\Form\Type\EqualType`

```markdown
### Changed
from `choices_as_value` to `choices_as_values`
```

### Subject

in respect of SF type form, the value for `choices_as_values` have to be ends with an "s"

