### PR TITLE
Added LegacyFormHelper to detect symfony versions

### DIFF
--- a/Form/FormHelper.php
+++ b/Form/FormHelper.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Form;
 
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -93,9 +94,9 @@ class FormHelper
      */
     public static function configureOptions(FormTypeInterface $type, OptionsResolver $optionsResolver)
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+        if (LegacyFormHelper::isLegacy()) {
             $type->setDefaultOptions($optionsResolver);
-        } else { // SF <2.8 BC
+        } else {
             $type->configureOptions($optionsResolver);
         }
     }

--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Form\Type;
 
 use Sonata\CoreBundle\Form\DataTransformer\BooleanTypeToBooleanTransformer;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -74,17 +75,9 @@ class BooleanType extends AbstractType
             },
         );
 
-        // SF 2.7+ BC
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_values'] = true;
-            }
-        }
-
         $defaultOptions['choices'] = $choices;
+
+        LegacyFormHelper::fixChoiceOptions($defaultOptions);
 
         $resolver->setDefaults($defaultOptions);
     }
@@ -94,10 +87,10 @@ class BooleanType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            'choice'
+        );
     }
 
     /**

--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Form\Type;
 
 use Sonata\CoreBundle\Color\Colors;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -56,10 +57,10 @@ class ColorSelectorType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            'choice'
+        );
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -49,10 +50,10 @@ class DatePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-           'Symfony\Component\Form\Extension\Core\Type\DateType' :
-           'date' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\DateType',
+            'date'
+        );
     }
 
     /**

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -52,10 +53,10 @@ class DateTimePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\DateTimeType' :
-            'datetime' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\DateTimeType',
+            'datetime'
+        );
     }
 
     /**

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -56,18 +57,9 @@ class EqualType extends AbstractType
         );
 
         $defaultOptions = array();
-
-        // SF 2.7+ BC
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_values'] = true;
-            }
-        }
-
         $defaultOptions['choices'] = $choices;
+
+        LegacyFormHelper::fixChoiceOptions($defaultOptions);
 
         $resolver->setDefaults($defaultOptions);
     }
@@ -77,10 +69,10 @@ class EqualType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            'choice'
+        );
     }
 
     /**

--- a/Form/Type/TranslatableChoiceType.php
+++ b/Form/Type/TranslatableChoiceType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -71,10 +72,10 @@ class TranslatableChoiceType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return LegacyFormHelper::getType(
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+            'choice'
+        );
     }
 
     /**

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -23,9 +24,10 @@ class BooleanTypeTest extends TypeTestCase
         $type = new BooleanType();
 
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            LegacyFormHelper::getType(
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                'choice'
+            ),
             $type->getParent()
         );
 

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ColorSelectorType;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -24,9 +25,10 @@ class ColorSelectorTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_color_selector', $type->getName());
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            LegacyFormHelper::getType(
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                'choice'
+            ),
             $type->getParent()
         );
 

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\EqualType;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -33,9 +34,10 @@ class EqualTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_equal', $type->getName());
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            LegacyFormHelper::getType(
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                'choice'
+            ),
             $type->getParent()
         );
 
@@ -44,20 +46,11 @@ class EqualTypeTest extends TypeTestCase
         $options = $resolver->resolve();
 
         $choices = array(1 => 'label_type_equals', 2 => 'label_type_not_equals');
-
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-        }
-
         $expected = array(
-            'choices_as_values' => true,
             'choices' => $choices,
         );
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')
-            || !method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-            unset($expected['choices_as_values']);
-        }
+        LegacyFormHelper::fixChoiceOptions($expected);
 
         $this->assertSame($expected, $options);
     }

--- a/Tests/Form/Type/TranslatableChoiceTypeTest.php
+++ b/Tests/Form/Type/TranslatableChoiceTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
+use Sonata\CoreBundle\Util\LegacyFormHelper;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,9 +28,10 @@ class TranslatableChoiceTypeTest extends TypeTestCase
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            LegacyFormHelper::getType(
+                'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
+                'choice'
+            ),
             $type->getParent()
         );
 

--- a/Util/LegacyFormHelper.php
+++ b/Util/LegacyFormHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Util;
+
+/**
+ * Helper class to handle the different behaviour of the corresponding symfony versions.
+ *
+ * @author Christian Gripp <mail@core23.de>
+ *
+ * @internal You shouldn't rely on this class when supporting only symfony >=2.8.
+ */
+final class LegacyFormHelper
+{
+    /**
+     * Detects if you are using an old symfony (<2.8) version.
+     *
+     * @return bool
+     */
+    public static function isLegacy()
+    {
+        return !self::isModern();
+    }
+
+    /**
+     * Detects if you are using a new (>=2.8) symfony version.
+     *
+     * @return bool
+     */
+    public static function isModern()
+    {
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+    }
+
+    /**
+     * Returns the correct form name according to your symfony version.
+     *
+     * @param string $className
+     * @param string $formName
+     *
+     * @return string
+     */
+    public static function getType($className, $formName)
+    {
+        return self::isModern() ? $className : $formName;
+    }
+
+    /**
+     * Flipps the choice options if you are using a new symfony version.
+     *
+     * @param array $options
+     */
+    public static function fixChoiceOptions(&$options)
+    {
+        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $options['choices'] = array_flip($options['choices']);
+
+            // choice_as_value options is not needed in SF 3.0+
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $options['choices_as_values'] = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this adds a new BC feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new `LegacyFormHelper` to handle the different form behavior
```

## Subject

Adds a new useful helper class to detect the symfony versions and handles the different behavior of forms.