### PR TITLE
added static setFormats and addFormat methods

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('sonata_core');
 
         $this->addFlashMessageSection($rootNode);
+        $this->addSerializerFormats($rootNode);
 
         $rootNode
             ->children()
@@ -102,6 +103,29 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Returns configuration for serializer formats.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addSerializerFormats(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('serializer')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('formats')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('json', 'xml', 'yml'))
+                            ->info('Default serializer formats, will be used while getting subscribing methods.')
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\DependencyInjection;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CoreBundle\Serializer\BaseSerializerHandler;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -69,6 +70,8 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
         $this->configureClassesToCompile();
 
         $this->deprecateSlugify($container);
+
+        $this->configureSerializerFormats($config);
     }
 
     public function configureClassesToCompile()
@@ -151,6 +154,14 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
         $definition->replaceArgument(3, $cssClasses);
 
         $container->setDefinition($identifier, $definition);
+    }
+
+    /**
+     * @param array $config
+     */
+    public function configureSerializerFormats($config)
+    {
+        BaseSerializerHandler::setFormats($config['serializer']['formats']);
     }
 
     protected function deprecateSlugify(ContainerBuilder $container)

--- a/Resources/doc/reference/serialization.rst
+++ b/Resources/doc/reference/serialization.rst
@@ -7,7 +7,22 @@ Serialization
 Custom handlers
 ---------------
 
-The bundle comes with a ``BaseSerializerHandler`` to let you customize your serialized entities; this handler is used to serialize/deserialize an entity to/from its id, but you remain free to create your own handler for your specific needs.
+The bundle comes with a ``BaseSerializerHandler`` to let you customize your serialized entities;
+this handler is used to serialize/deserialize an entity to/from its id within the defaults
+formats ('json', 'xml', 'yml').
+
+The serializer default formats are configurable. You can change them from the configuration file.
+
+.. code-block:: yaml
+
+        sonata_core:
+            serializer:
+                formats: ['json', 'xml', 'yml']
+
+You can set these formats to a different array or you can add another format to these formats by using
+``BaseSerializerHandler`` methods ``setFormats`` and ``addFormat``
+
+You are free to create your own handler for your specific needs.
 
 Just override ``Sonata\CoreBundle\Serializer\BaseSerializerHandler`` to create a `JMS Serializer` handler.
 

--- a/Serializer/BaseSerializerHandler.php
+++ b/Serializer/BaseSerializerHandler.php
@@ -27,6 +27,11 @@ abstract class BaseSerializerHandler implements SerializerHandlerInterface
     protected $manager;
 
     /**
+     * @var string[]
+     */
+    protected static $formats;
+
+    /**
      * @param ManagerInterface $manager
      */
     public function __construct(ManagerInterface $manager)
@@ -35,15 +40,41 @@ abstract class BaseSerializerHandler implements SerializerHandlerInterface
     }
 
     /**
+     * @param string[] $formats
+     */
+    final public static function setFormats(array $formats)
+    {
+        static::$formats = $formats;
+    }
+
+    /**
+     * @param string $format
+     */
+    final public static function addFormat($format)
+    {
+        static::$formats[] = $format;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribingMethods()
     {
+        // NEXT_MAJOR : remove this block
+        if (null === static::$formats) {
+            static::$formats = array('json', 'xml', 'yml');
+            @trigger_error(
+                '$formats has been set to default array("json", "xml", "yml"). Setting $formats to a 
+                default array is deprecated since version 3.0 and will be removed in 4.0. Use SonataCoreBundle 
+                configuration to add default serializer formats.',
+                E_USER_DEPRECATED
+            );
+        }
+
         $type = static::getType();
-        $formats = array('json', 'xml', 'yml');
         $methods = array();
 
-        foreach ($formats as $format) {
+        foreach (static::$formats as $format) {
             $methods[] = array(
                 'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                 'format' => $format,

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -46,6 +46,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
                     'extension' => array(),
                 ),
             ),
+            'serializer' => array(
+                'formats' => array('json', 'xml', 'yml'),
+            ),
         ));
     }
 
@@ -80,6 +83,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             ),
             'form_type' => 'standard',
             'flashmessage' => array(),
+            'serializer' => array(
+                'formats' => array('json', 'xml', 'yml'),
+            ),
         ));
     }
 
@@ -97,6 +103,9 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             ),
             'form_type' => 'standard',
             'flashmessage' => array(),
+            'serializer' => array(
+                'formats' => array('json', 'xml', 'yml'),
+            ),
         ));
     }
 }

--- a/Tests/Serializer/BaseSerializerHandlerTest.php
+++ b/Tests/Serializer/BaseSerializerHandlerTest.php
@@ -19,7 +19,12 @@ use Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer;
  */
 final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetSubscribingMethods()
+    /**
+     * @group legacy
+     *
+     * NEXT_MAJOR : this should call setFormats method
+     */
+    public function testGetSubscribingMethodsWithDefaultFormats()
     {
         $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
 
@@ -64,7 +69,77 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $methods = $serializer->getSubscribingMethods();
+        $methods = $serializer::getSubscribingMethods();
+
+        $this->assertSame($methods, $expectedMethods);
+    }
+
+    public function testSetFormats()
+    {
+        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+
+        $serializer = new FooSerializer($manager);
+
+        $expectedMethods = array(
+            array(
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => 'bar',
+                'type' => 'foo',
+                'method' => 'serializeObjectToId',
+            ),
+            array(
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => 'bar',
+                'type' => 'foo',
+                'method' => 'deserializeObjectFromId',
+            ),
+        );
+
+        $serializer::setFormats(array('bar'));
+
+        $methods = $serializer::getSubscribingMethods();
+
+        $this->assertSame($methods, $expectedMethods);
+    }
+
+    public function testAddFormats()
+    {
+        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+
+        $serializer = new FooSerializer($manager);
+
+        $expectedMethods = array(
+            array(
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => 'bar',
+                'type' => 'foo',
+                'method' => 'serializeObjectToId',
+            ),
+            array(
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => 'bar',
+                'type' => 'foo',
+                'method' => 'deserializeObjectFromId',
+            ),
+            array(
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => 'foo',
+                'type' => 'foo',
+                'method' => 'serializeObjectToId',
+            ),
+            array(
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => 'foo',
+                'type' => 'foo',
+                'method' => 'deserializeObjectFromId',
+            ),
+        );
+
+        $serializer::setFormats(array('bar'));
+
+        $serializer::addFormat('foo');
+
+        $methods = $serializer::getSubscribingMethods();
 
         $this->assertSame($methods, $expectedMethods);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #306

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Added
- Added static `setFormats` and `addFormat` methods to `BaseSerializerHandler`
- Added `sonata.core.serializer.formats` configuration
```

