### PR TITLE
Fix duplicate translation in filter types.

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -20,15 +20,24 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateRangeType extends AbstractType
 {
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface|null
+     *
+     * @deprecated Translator property is deprecated since version 3.1, to be removed in 4.0.
      */
     protected $translator;
 
     /**
-     * @param TranslatorInterface $translator
+     * @param TranslatorInterface|null $translator
+     *
+     * @deprecated Translator dependency is deprecated since version 3.1, to be removed in 4.0.
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator = null)
     {
+        // check if class is overloaded and notifiy about removing deprecated translator
+        if ($translator !== null && get_class($this) !== get_class() && get_class($this) !== 'Sonata\CoreBundle\Form\Type\DateRangePickerType') {
+            @trigger_error('The translator dependency in Sonata`s DateRangeType is deprecated since 3.1 and will be removed in 4.0. Please prepare your dependencies for this change.', E_USER_DEPRECATED);
+        }
+
         $this->translator = $translator;
     }
 
@@ -39,14 +48,16 @@ class DateRangeType extends AbstractType
     {
         $options['field_options_start'] = array_merge(
             array(
-                'label' => $this->translator->trans('date_range_start', array(), 'SonataCoreBundle'),
+                'label' => 'date_range_start',
+                'translation_domain' => 'SonataCoreBundle',
             ),
             $options['field_options_start']
         );
 
         $options['field_options_end'] = array_merge(
             array(
-                'label' => $this->translator->trans('date_range_end', array(), 'SonataCoreBundle'),
+                'label' => 'date_range_end',
+                'translation_domain' => 'SonataCoreBundle',
             ),
             $options['field_options_end']
         );

--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -20,15 +20,24 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DateTimeRangeType extends AbstractType
 {
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface|null
+     *
+     * @deprecated Translator property is deprecated since version 3.1, to be removed in 4.0.
      */
     protected $translator;
 
     /**
-     * @param TranslatorInterface $translator
+     * @param TranslatorInterface|null $translator
+     *
+     * @deprecated Translator dependency is deprecated since version 3.1, to be removed in 4.0.
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator = null)
     {
+        // check if class is overloaded and notifiy about removing deprecated translator
+        if ($translator !== null && get_class($this) !== get_class() && get_class($this) !== 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType') {
+            @trigger_error('The translator dependency in Sonata`s DateTimeRangeType is deprecated since 3.1 and will be removed in 4.0. Please prepare your dependencies for this change.', E_USER_DEPRECATED);
+        }
+
         $this->translator = $translator;
     }
 
@@ -39,14 +48,16 @@ class DateTimeRangeType extends AbstractType
     {
         $options['field_options_start'] = array_merge(
             array(
-                'label' => $this->translator->trans('date_range_start', array(), 'SonataCoreBundle'),
+                'label' => 'date_range_start',
+                'translation_domain' => 'SonataCoreBundle',
             ),
             $options['field_options_start']
         );
 
         $options['field_options_end'] = array_merge(
             array(
-                'label' => $this->translator->trans('date_range_end', array(), 'SonataCoreBundle'),
+                'label' => 'date_range_end',
+                'translation_domain' => 'SonataCoreBundle',
             ),
             $options['field_options_end']
         );

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -23,15 +23,24 @@ class EqualType extends AbstractType
     const TYPE_IS_NOT_EQUAL = 2;
 
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface|null
+     *
+     * @deprecated Translator property is deprecated since version 3.1, to be removed in 4.0.
      */
     protected $translator;
 
     /**
-     * @param TranslatorInterface $translator
+     * @param TranslatorInterface|null $translator
+     *
+     * @deprecated Translator dependency is deprecated since version 3.1, to be removed in 4.0.
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator = null)
     {
+        // check if class is overloaded and notifiy about removing deprecated translator
+        if ($translator !== null && get_class($this) !== get_class()) {
+            @trigger_error('The translator dependency in Sonata`s EqualType is deprecated since 3.1 and will be removed in 4.0. Please prepare your dependencies for this change.', E_USER_DEPRECATED);
+        }
+
         $this->translator = $translator;
     }
 
@@ -51,11 +60,11 @@ class EqualType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $choices = array(
-            self::TYPE_IS_EQUAL => $this->translator->trans('label_type_equals', array(), 'SonataCoreBundle'),
-            self::TYPE_IS_NOT_EQUAL => $this->translator->trans('label_type_not_equals', array(), 'SonataCoreBundle'),
+            self::TYPE_IS_EQUAL => 'label_type_equals',
+            self::TYPE_IS_NOT_EQUAL => 'label_type_not_equals',
         );
 
-        $defaultOptions = array();
+        $defaultOptions = array('translation_domain' => 'SonataCoreBundle');
 
         // SF 2.7+ BC
         if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -22,7 +22,7 @@ class EqualTypeTest extends TypeTestCase
     {
         $mock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
 
-        $mock->expects($this->exactly(2))
+        $mock->expects($this->exactly(0))
             ->method('trans')
             ->will($this->returnCallback(function ($arg) {
                 return $arg;
@@ -50,6 +50,7 @@ class EqualTypeTest extends TypeTestCase
         }
 
         $expected = array(
+            'translation_domain' => 'SonataCoreBundle',
             'choices_as_values' => true,
             'choices' => $choices,
         );

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,0 +1,4 @@
+UPGRADE FROM 3.X to 4.0
+=======================
+
+### The translator dependency in DateRangeType, DateTimeRangeType, EqualType has been removed. You should fix the dependencies if you overload one of these form types.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch to fix duplicate translation labels mentioned in sonata-project/SonataAdminBundle#3283. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes partially sonata-project/SonataAdminBundle#3283

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Translator dependency in `DateRangeType`, `DateTimeRangeType` and `EqualType` is deprecated, to be removed in 4.0.

### Fixed
- Duplicate translation in `DateRangeType`, `DateTimeRangeType` and `EqualType`.
```

## To do
This PR is ready. I will create another for SonataAdminBundle and also one for SonataCore master brach after merging, that will remove the translator dependency from DateRangeType, DateTimeRangeType, EqualType as it's not needed anymore (BC break).


## Subject

Fix duplicate translation in filter types.

