### PR TITLE
Fix sf3 form type

### DIFF
--- a/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/Form/Type/BaseDoctrineORMSerializationType.php
@@ -117,10 +117,17 @@ class BaseDoctrineORMSerializationType extends AbstractType
                     $nullable = $associationMetadata['inverseJoinColumns']['nullable'];
                 }
             }
-
             switch ($type) {
                 case 'datetime':
-                    $builder->add($name, $type, array('required' => !$nullable, 'widget' => 'single_text'));
+                    $builder->add(
+                        $name,
+                        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
+                        // (when requirement of Symfony is >= 2.8)
+                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                            ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
+                            : 'datetime',
+                        array('required' => !$nullable, 'widget' => 'single_text')
+                    );
                     break;
 
                 case 'boolean':

--- a/Form/Type/BaseStatusType.php
+++ b/Form/Type/BaseStatusType.php
@@ -56,7 +56,11 @@ abstract class BaseStatusType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+        // (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice';
     }
 
     /**

--- a/Form/Type/CollectionType.php
+++ b/Form/Type/CollectionType.php
@@ -62,7 +62,11 @@ class CollectionType extends AbstractType
     {
         $resolver->setDefaults(array(
             'modifiable' => false,
-            'type' => 'text',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            // (when requirement of Symfony is >= 2.8)
+            'type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
             'type_options' => array(),
             'pre_bind_data_callback' => null,
             'btn_add' => 'link_add',

--- a/Form/Type/DateRangePickerType.php
+++ b/Form/Type/DateRangePickerType.php
@@ -29,7 +29,11 @@ class DateRangePickerType extends DateRangeType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => 'sonata_type_date_picker',
+            // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DatePickerType'
+            // (when requirement of Symfony is >= 2.8)
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
+                : 'sonata_type_date_picker',
         ));
     }
 

--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -90,7 +90,11 @@ class DateRangeType extends AbstractType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => 'date',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateType'
+            // (when requirement of Symfony is >= 2.8)
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
+                : 'date',
         ));
     }
 }

--- a/Form/Type/DateTimeRangePickerType.php
+++ b/Form/Type/DateTimeRangePickerType.php
@@ -29,7 +29,11 @@ class DateTimeRangePickerType extends DateTimeRangeType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => 'sonata_type_datetime_picker',
+            // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
+            // (when requirement of Symfony is >= 2.8)
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
+                : 'sonata_type_datetime_picker',
         ));
     }
 

--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -90,7 +90,11 @@ class DateTimeRangeType extends AbstractType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => 'datetime',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
+            // (when requirement of Symfony is >= 2.8)
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
+                : 'datetime',
         ));
     }
 }

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -14,10 +14,86 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BooleanTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new BooleanType();
+
+        $type->buildForm($formBuilder, array(
+            'transform' => false,
+
+            // @deprecated Deprecated as of SonataCoreBundle 2.3.10, to be removed in 4.0.
+            'catalogue' => 'SonataCoreBundle',
+
+            // Use directly translation_domain in SonataCoreBundle 4.0
+            'translation_domain' => function (Options $options) {
+                if ($options['catalogue']) {
+                    return $options['catalogue'];
+                }
+
+                return $options['translation_domain'];
+            },
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new BooleanType();
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new BooleanType();

--- a/Tests/Form/Type/CollectionTypeTest.php
+++ b/Tests/Form/Type/CollectionTypeTest.php
@@ -18,6 +18,76 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CollectionTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new CollectionType();
+
+        $type->buildForm($formBuilder, array(
+            'modifiable' => false,
+            'type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
+            'type_options' => array(),
+            'pre_bind_data_callback' => null,
+            'btn_add' => 'link_add',
+            'btn_catalogue' => 'SonataCoreBundle',
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new CollectionType();
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new CollectionType();
@@ -27,7 +97,14 @@ class CollectionTypeTest extends TypeTestCase
         $options = $optionResolver->resolve();
 
         $this->assertFalse($options['modifiable']);
-        $this->assertSame('text', $options['type']);
+        $this->assertSame(
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
+            $options['type']
+        );
         $this->assertSame(0, count($options['type_options']));
         $this->assertSame('link_add', $options['btn_add']);
         $this->assertSame('SonataCoreBundle', $options['btn_catalogue']);

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
+use Sonata\CoreBundle\Color\Colors;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ColorSelectorType;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -18,6 +19,82 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ColorSelectorTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new ColorSelectorType();
+
+        $type->buildForm($formBuilder, array(
+            'choices' => Colors::getAll(),
+            'translation_domain' => 'SonataCoreBundle',
+            'preferred_choices' => array(
+                Colors::BLACK,
+                Colors::BLUE,
+                Colors::GRAY,
+                Colors::GREEN,
+                Colors::ORANGE,
+                Colors::PINK,
+                Colors::PURPLE,
+                Colors::RED,
+                Colors::WHITE,
+                Colors::YELLOW,
+            ),
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new ColorSelectorType();
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new ColorSelectorType();

--- a/Tests/Form/Type/DatePickerTypeTest.php
+++ b/Tests/Form/Type/DatePickerTypeTest.php
@@ -13,12 +13,82 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DatePickerType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
 class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new DatePickerType(
+            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+        );
+        $type->buildForm($formBuilder, array(
+            'dp_pick_time' => false,
+            'format' => DateType::DEFAULT_FORMAT,
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new DatePickerType(
+            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+        );
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetName()
     {
         $type = new DatePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));

--- a/Tests/Form/Type/DateRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateRangePickerTypeTest.php
@@ -18,6 +18,73 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateRangePickerTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type->buildForm($formBuilder, array(
+            'field_options' => array(),
+            'field_options_start' => array(),
+            'field_options_end' => array(),
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
+                : 'sonata_type_date_picker',
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
@@ -33,7 +100,11 @@ class DateRangePickerTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                'field_type' => 'sonata_type_date_picker',
+                // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DatePickerType'
+                // (when requirement of Symfony is >= 2.8)
+                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
+                    : 'sonata_type_date_picker',
             ), $options);
     }
 }

--- a/Tests/Form/Type/DateRangeTypeTest.php
+++ b/Tests/Form/Type/DateRangeTypeTest.php
@@ -18,6 +18,73 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateRangeTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type->buildForm($formBuilder, array(
+            'field_options' => array(),
+            'field_options_start' => array(),
+            'field_options_end' => array(),
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
+                : 'date',
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
@@ -33,7 +100,11 @@ class DateRangeTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                'field_type' => 'date',
+                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateType'
+                // (when requirement of Symfony is >= 2.8)
+                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
+                    : 'date',
             ), $options);
     }
 }

--- a/Tests/Form/Type/DateTimePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimePickerTypeTest.php
@@ -13,12 +13,86 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
 class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new DateTimePickerType(
+            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+        );
+
+        $type->buildForm($formBuilder, array(
+            'dp_use_minutes' => true,
+            'dp_use_seconds' => true,
+            'dp_minute_stepping' => 1,
+            'format' => DateTimeType::DEFAULT_DATE_FORMAT,
+            'date_format' => null,
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new DateTimePickerType(
+            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+        );
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetName()
     {
         $type = new DateTimePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));

--- a/Tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -18,6 +18,73 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateTimeRangePickerTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type->buildForm($formBuilder, array(
+            'field_options' => array(),
+            'field_options_start' => array(),
+            'field_options_end' => array(),
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
+                : 'sonata_type_datetime_picker',
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
@@ -33,7 +100,11 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                'field_type' => 'sonata_type_datetime_picker',
+                // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
+                // (when requirement of Symfony is >= 2.8)
+                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
+                    : 'sonata_type_datetime_picker',
             ), $options);
     }
 }

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -18,6 +18,68 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EqualTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type->buildForm($formBuilder, array(
+            'choices' => array(),
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $mock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');

--- a/Tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/Tests/Form/Type/ImmutableArrayTypeTest.php
@@ -19,6 +19,68 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImmutableArrayTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new ImmutableArrayType();
+        $type->buildForm($formBuilder, array(
+            'keys' => array(),
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new ImmutableArrayType();
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         $type = new ImmutableArrayType();
@@ -48,7 +110,11 @@ class ImmutableArrayTypeTest extends TypeTestCase
                 return $name === 'ttl';
             }),
             $this->callback(function ($name) {
-                return $name === 'text';
+                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                // (when requirement of Symfony is >= 2.8)
+                return $name === method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                    : 'text';
             }),
             $this->callback(function ($name) {
                 return $name === array(1 => '1');
@@ -59,7 +125,14 @@ class ImmutableArrayTypeTest extends TypeTestCase
         $optionsCallback = function ($builder, $name, $type, $extra) use ($self) {
             $self->assertEquals(array('foo', 'bar'), $extra);
             $self->assertEquals($name, 'ttl');
-            $self->assertEquals($type, 'text');
+            $self->assertEquals(
+                $type,
+                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                // (when requirement of Symfony is >= 2.8)
+                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                    : 'text'
+            );
             $self->assertInstanceOf('Symfony\Component\Form\Test\FormBuilderInterface', $builder);
 
             return array('1' => '1');
@@ -67,7 +140,17 @@ class ImmutableArrayTypeTest extends TypeTestCase
 
         $options = array(
             'keys' => array(
-                array('ttl', 'text', $optionsCallback, 'foo', 'bar'),
+                array(
+                    'ttl',
+                    // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                    // (when requirement of Symfony is >= 2.8)
+                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                        ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                        : 'text',
+                    $optionsCallback,
+                    'foo',
+                    'bar',
+                ),
             ),
         );
 

--- a/Tests/Form/Type/StatusTypeTest.php
+++ b/Tests/Form/Type/StatusTypeTest.php
@@ -31,6 +31,68 @@ class StatusType extends \Sonata\CoreBundle\Form\Type\BaseStatusType
 
 class StatusTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
+        $type->buildForm($formBuilder, array(
+            'choices' => array(),
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testGetDefaultOptions()
     {
         Choice::$list = array(
@@ -40,7 +102,15 @@ class StatusTypeTest extends TypeTestCase
         $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
 
         $this->assertSame('choice_type', $type->getName());
-        $this->assertSame('choice', $type->getParent());
+
+        $this->assertSame(
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice',
+            $type->getParent()
+        );
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
@@ -60,7 +130,14 @@ class StatusTypeTest extends TypeTestCase
         $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type', true);
 
         $this->assertSame('choice_type', $type->getName());
-        $this->assertSame('choice', $type->getParent());
+        $this->assertSame(
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice',
+            $type->getParent()
+        );
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
@@ -83,7 +160,13 @@ class StatusTypeTest extends TypeTestCase
         $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type', true);
 
         $this->assertSame('choice_type', $type->getName());
-        $this->assertSame('choice', $type->getParent());
+        $this->assertSame(
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+                : 'choice',
+            $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/Tests/Form/Type/TranslatableChoiceTypeTest.php
+++ b/Tests/Form/Type/TranslatableChoiceTypeTest.php
@@ -18,6 +18,68 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TranslatableChoiceTypeTest extends TypeTestCase
 {
+    public function testBuildForm()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $type = new TranslatableChoiceType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type->buildForm($formBuilder, array(
+            'catalogue' => 'messages',
+        ));
+    }
+
+    public function testGetParent()
+    {
+        $form = new TranslatableChoiceType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $form->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
     public function testLegacyGetDefaultOptions()
     {
         $stub = $this->getMock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
I am targeting `3.x`, because it's the branch that should be compatible with Symfony 3+ but isn't.

## Changelog

```markdown
### Fixed
- Fixed `BaseDoctrineORMSerializationType::buildForm` compatibility with Symfony3 forms
- Fixed `BaseStatusType::getParent ` compatibility with Symfony3 forms
- Fixed `CollectionType::configureOptions` compatibility with Symfony3 forms
- Fixed `DateRangePickerType::configureOptions` compatibility with Symfony3 forms
- Fixed `DateRangeType::configureOptions` compatibility with Symfony3 forms
- Fixed `DateTimeRangePickerType::configureOptions` compatibility with Symfony3 forms
- Fixed `DateTimeRangeType::configureOptions` compatibility with Symfony3 forms
```

## Subject

Forms are not compatible with Symfony3 because it is currently using form short name instead of the FQCN. Since Symfony 3.0, you have to `'Symfony\Component\Form\Extension\Core\Type\TextType'` instead of `'text'`.