### PR TITLE
Deprecate exporter

### DIFF
--- a/Exporter/Exporter.php
+++ b/Exporter/Exporter.php
@@ -18,6 +18,15 @@ use Exporter\Writer\XlsWriter;
 use Exporter\Writer\XmlWriter;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\Exporter class is deprecated since version 3.x and will be removed in 4.0.'.
+    ' Use Exporter\Exporter instead',
+    E_USER_DEPRECATED
+);
+
+/**
+ * NEXT_MAJOR: remove this class, and the dev dependency.
+ */
 class Exporter
 {
     /**

--- a/Resources/config/exporter.xml
+++ b/Resources/config/exporter.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- NEXT_MAJOR : remove this file -->
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.core.exporter" class="Sonata\CoreBundle\Exporter\Exporter"/>

--- a/Tests/Exporter/ExporterTest.php
+++ b/Tests/Exporter/ExporterTest.php
@@ -14,6 +14,11 @@ namespace Sonata\CoreBundle\Tests\Exporter;
 use Exporter\Source\ArraySourceIterator;
 use Sonata\CoreBundle\Exporter\Exporter;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @group legacy
+ */
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -115,7 +115,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             }));
 
         $type = new DoctrineORMSerializationType(
-            $this->getMetadataFactoryMock(),// $this->getMock('Metadata\MetadataFactoryInterface'),
+            $this->getMetadataFactoryMock(), // $this->getMock('Metadata\MetadataFactoryInterface'),
             $this->getRegistryMock(),
             'form_type_test',
             $this->class,

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,3 +6,10 @@ UPGRADE 3.x
 All files under the ``Tests`` directory are now correctly handled as internal test classes.
 You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
+
+### Deprecated exporter class and service
+
+The exporter class and service are now deprecated in favor of very similar equivalents from the
+[`sonata-project/exporter`](https://github.com/sonata-project/exporter) library,
+which are available since version 1.6.0,
+if you enable the bundle as described in the documentation.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -3,4 +3,6 @@ UPGRADE 3.x
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. You can't extend them anymore, because they are only loaded when running internal tests. More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
+More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).


### PR DESCRIPTION
I am targetting this branch, because this is BC

Closes #50

## Changelog

```markdown
### Deprecated
- Exporter class and service : use equivalents from `sonata-project/exporter` instead.
```

## To do

- [x] Wait for 1.6.0 to be released

## Subject

This deprecates the export class and service
