### PR TITLE
Added option to override template location in AbstractWidgetTestCase

### DIFF
--- a/Test/AbstractWidgetTestCase.php
+++ b/Test/AbstractWidgetTestCase.php
@@ -60,6 +60,24 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
      */
     protected function getEnvironment()
     {
+        $loader = new StubFilesystemLoader($this->getTemplatePaths());
+
+        $environment = new \Twig_Environment($loader, array(
+            'strict_variables' => true,
+        ));
+        $environment->addExtension(new TranslationExtension(new StubTranslator()));
+        $environment->addExtension($this->extension);
+
+        return $environment;
+    }
+
+    /**
+     * Returns a list of template paths.
+     *
+     * @return string[]
+     */
+    protected function getTemplatePaths()
+    {
         // this is an workaround for different composer requirements and different TwigBridge installation directories
         $twigPaths = array_filter(array(
             // symfony/twig-bridge (running from this bundle)
@@ -79,15 +97,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
 
         $twigPaths[] = __DIR__.'/../Resources/views/Form';
 
-        $loader = new StubFilesystemLoader($twigPaths);
-
-        $environment = new \Twig_Environment($loader, array(
-            'strict_variables' => true,
-        ));
-        $environment->addExtension(new TranslationExtension(new StubTranslator()));
-        $environment->addExtension($this->extension);
-
-        return $environment;
+        return $twigPaths;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `AbstractWidgetTestCase::getTemplatePaths` method
```

## Subject

Should be the final PR for using the test case outside the bundle.

