### PR TITLE
Bump symfony version to 2.8

### DIFF
--- a/Form/FormHelper.php
+++ b/Form/FormHelper.php
@@ -93,10 +93,6 @@ class FormHelper
      */
     public static function configureOptions(FormTypeInterface $type, OptionsResolver $optionsResolver)
     {
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $type->setDefaultOptions($optionsResolver);
-        } else { // SF <2.8 BC
-            $type->configureOptions($optionsResolver);
-        }
+        $type->configureOptions($optionsResolver);
     }
 }

--- a/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/Form/Type/BaseDoctrineORMSerializationType.php
@@ -18,7 +18,6 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * This is a doctrine serialization form type that generates a form type from class serialization metadata
@@ -117,11 +116,7 @@ class BaseDoctrineORMSerializationType extends AbstractType
                 case 'datetime':
                     $builder->add(
                         $name,
-                        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-                        // (when requirement of Symfony is >= 2.8)
-                        method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                            ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-                            : 'datetime',
+                        'Symfony\Component\Form\Extension\Core\Type\DateTimeType',
                         array('required' => !$nullable, 'widget' => 'single_text')
                     );
                     break;
@@ -153,16 +148,6 @@ class BaseDoctrineORMSerializationType extends AbstractType
     public function getName()
     {
         return $this->getBlockPrefix();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
     }
 
     /**

--- a/Form/Type/BaseStatusType.php
+++ b/Form/Type/BaseStatusType.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 abstract class BaseStatusType extends AbstractType
 {
@@ -56,11 +55,7 @@ abstract class BaseStatusType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-        // (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
     /**
@@ -77,16 +72,6 @@ abstract class BaseStatusType extends AbstractType
     public function getName()
     {
         return $this->getBlockPrefix();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
     }
 
     /**

--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -16,7 +16,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class BooleanType extends AbstractType
 {
@@ -36,22 +35,12 @@ class BooleanType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $choices = array(
-            self::TYPE_YES => 'label_type_yes',
-            self::TYPE_NO => 'label_type_no',
+            'label_type_yes' => self::TYPE_YES,
+            'label_type_no' => self::TYPE_NO,
         );
 
         $defaultOptions = array(
@@ -59,16 +48,11 @@ class BooleanType extends AbstractType
             'translation_domain' => 'SonataCoreBundle',
         );
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
+        $defaultOptions['choice_translation_domain'] = 'SonataCoreBundle';
 
-            $defaultOptions['choice_translation_domain'] = 'SonataCoreBundle';
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_values'] = true;
-            }
+        // choice_as_value options is not needed in SF 3.0+
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $defaultOptions['choices_as_values'] = true;
         }
 
         $defaultOptions['choices'] = $choices;
@@ -81,10 +65,7 @@ class BooleanType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
     /**

--- a/Form/Type/CollectionType.php
+++ b/Form/Type/CollectionType.php
@@ -17,7 +17,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class CollectionType extends AbstractType
 {
@@ -47,26 +46,12 @@ class CollectionType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'modifiable' => false,
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            // (when requirement of Symfony is >= 2.8)
-            'type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'type_options' => array(),
             'pre_bind_data_callback' => null,
             'btn_add' => 'link_add',

--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -14,20 +14,9 @@ namespace Sonata\CoreBundle\Form\Type;
 use Sonata\CoreBundle\Color\Colors;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ColorSelectorType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -56,10 +45,7 @@ class ColorSelectorType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
     /**

--- a/Form/Type/DatePickerType.php
+++ b/Form/Type/DatePickerType.php
@@ -13,23 +13,12 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
 class DatePickerType extends BasePickerType
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -46,10 +35,7 @@ class DatePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-           'Symfony\Component\Form\Extension\Core\Type\DateType' :
-           'date' // SF <2.8 BC
-        ;
+        return 'Symfony\Component\Form\Extension\Core\Type\DateType';
     }
 
     /**

--- a/Form/Type/DateRangePickerType.php
+++ b/Form/Type/DateRangePickerType.php
@@ -29,11 +29,7 @@ class DateRangePickerType extends DateRangeType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DatePickerType'
-            // (when requirement of Symfony is >= 2.8)
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
-                : 'sonata_type_date_picker',
+            'field_type' => 'Sonata\CoreBundle\Form\Type\DatePickerType',
         ));
     }
 

--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DateRangeType extends AbstractType
@@ -92,16 +91,6 @@ class DateRangeType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -109,11 +98,7 @@ class DateRangeType extends AbstractType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateType'
-            // (when requirement of Symfony is >= 2.8)
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
-                : 'date',
+            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\DateType',
         ));
     }
 }

--- a/Form/Type/DateTimePickerType.php
+++ b/Form/Type/DateTimePickerType.php
@@ -13,23 +13,12 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
 class DateTimePickerType extends BasePickerType
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -49,10 +38,7 @@ class DateTimePickerType extends BasePickerType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\DateTimeType' :
-            'datetime' // SF <2.8 BC
-        ;
+        return 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
     }
 
     /**

--- a/Form/Type/DateTimeRangePickerType.php
+++ b/Form/Type/DateTimeRangePickerType.php
@@ -29,11 +29,7 @@ class DateTimeRangePickerType extends DateTimeRangeType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
-            // (when requirement of Symfony is >= 2.8)
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
-                : 'sonata_type_datetime_picker',
+            'field_type' => 'Sonata\CoreBundle\Form\Type\DateTimePickerType',
         ));
     }
 

--- a/Form/Type/DateTimeRangeType.php
+++ b/Form/Type/DateTimeRangeType.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class DateTimeRangeType extends AbstractType
@@ -92,16 +91,6 @@ class DateTimeRangeType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -109,11 +98,7 @@ class DateTimeRangeType extends AbstractType
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-            // (when requirement of Symfony is >= 2.8)
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-                : 'datetime',
+            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\DateTimeType',
         ));
     }
 }

--- a/Form/Type/EqualType.php
+++ b/Form/Type/EqualType.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class EqualType extends AbstractType
@@ -54,36 +53,21 @@ class EqualType extends AbstractType
 
     /**
      * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $choices = array(
-            self::TYPE_IS_EQUAL => 'label_type_equals',
-            self::TYPE_IS_NOT_EQUAL => 'label_type_not_equals',
+            'label_type_equals' => self::TYPE_IS_EQUAL,
+            'label_type_not_equals' => self::TYPE_IS_NOT_EQUAL,
         );
 
         $defaultOptions = array(
             'choice_translation_domain' => 'SonataCoreBundle',
         );
 
-        // SF 2.7+ BC
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $defaultOptions['choices_as_values'] = true;
-            }
+        // NEXT_MAJOR: choice_as_value options is not needed in SF 3.0+
+        if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+            $defaultOptions['choices_as_values'] = true;
         }
 
         $defaultOptions['choices'] = $choices;
@@ -96,10 +80,7 @@ class EqualType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice' // SF <2.8 BC
-        ;
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
     /**

--- a/Form/Type/ImmutableArrayType.php
+++ b/Form/Type/ImmutableArrayType.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ImmutableArrayType extends AbstractType
 {
@@ -44,16 +43,6 @@ class ImmutableArrayType extends AbstractType
                 $builder->add($name, $type, $options);
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @todo Remove it when bumping requirements to SF 2.7+
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
     }
 
     /**

--- a/Test/AbstractWidgetTestCase.php
+++ b/Test/AbstractWidgetTestCase.php
@@ -50,15 +50,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         }
         parent::setUp();
 
-        // NEXT_MAJOR: Remove BC hack when dropping symfony 2.4 support
-        $csrfProviderClasses = array_filter(array(
-            // symfony <=2.4
-            'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface',
-            // symfony >=2.4
-            'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface',
-        ), 'interface_exists');
-
-        $this->renderer = new TwigRenderer($this->getRenderingEngine(), $this->getMock(current($csrfProviderClasses)));
+        $this->renderer = new TwigRenderer($this->getRenderingEngine(), $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'));
 
         $this->extension = new FormExtension($this->renderer);
         $environment = $this->getEnvironment();
@@ -108,9 +100,6 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
             __DIR__.'/../vendor/symfony/twig-bridge/Resources/views/Form',
             // symfony/twig-bridge (running from other bundles)
             __DIR__.'/../../../symfony/twig-bridge/Resources/views/Form',
-            // NEXT_MAJOR: Remove BC hacks when dropping symfony 2.3 support
-            // symfony/twig-bridge 2.3 (running from this bundle)
-            __DIR__.'/../vendor/symfony/twig-bridge/Symfony/Bridge/Twig/Resources/views/Form',
             // symfony/twig-bridge 2.3 (running from other bundles)
             __DIR__.'/../../../symfony/twig-bridge/Symfony/Bridge/Twig/Resources/views/Form',
             // symfony/symfony (running from this bundle)

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -25,24 +25,8 @@ class BooleanTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -58,25 +42,9 @@ class BooleanTypeTest extends TypeTestCase
     {
         $form = new BooleanType();
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -84,9 +52,7 @@ class BooleanTypeTest extends TypeTestCase
         $type = new BooleanType();
 
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent()
         );
 
@@ -150,8 +116,7 @@ class BooleanTypeTest extends TypeTestCase
             'choices' => array(1 => 'foo_yes', 2 => 'foo_no'),
         );
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')
-            || !method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             unset($expectedOptions['choices_as_values']);
         }
 

--- a/Tests/Form/Type/CollectionTypeTest.php
+++ b/Tests/Form/Type/CollectionTypeTest.php
@@ -25,24 +25,8 @@ class CollectionTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -50,9 +34,7 @@ class CollectionTypeTest extends TypeTestCase
 
         $type->buildForm($formBuilder, array(
             'modifiable' => false,
-            'type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'type_options' => array(),
             'pre_bind_data_callback' => null,
             'btn_add' => 'link_add',
@@ -64,25 +46,9 @@ class CollectionTypeTest extends TypeTestCase
     {
         $form = new CollectionType();
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -95,11 +61,7 @@ class CollectionTypeTest extends TypeTestCase
 
         $this->assertFalse($options['modifiable']);
         $this->assertSame(
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
+            'Symfony\Component\Form\Extension\Core\Type\TextType',
             $options['type']
         );
         $this->assertSame(0, count($options['type_options']));

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -26,24 +26,8 @@ class ColorSelectorTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -71,25 +55,9 @@ class ColorSelectorTypeTest extends TypeTestCase
     {
         $form = new ColorSelectorType();
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -98,9 +66,7 @@ class ColorSelectorTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_color_selector', $type->getName());
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent()
         );
 

--- a/Tests/Form/Type/DatePickerTypeTest.php
+++ b/Tests/Form/Type/DatePickerTypeTest.php
@@ -27,24 +27,8 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $that->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -65,25 +49,9 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
             $this->getMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetName()

--- a/Tests/Form/Type/DateRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateRangePickerTypeTest.php
@@ -25,24 +25,8 @@ class DateRangePickerTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -51,9 +35,7 @@ class DateRangePickerTypeTest extends TypeTestCase
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
-                : 'sonata_type_date_picker',
+            'field_type' => 'Sonata\CoreBundle\Form\Type\DatePickerType',
         ));
     }
 
@@ -61,25 +43,9 @@ class DateRangePickerTypeTest extends TypeTestCase
     {
         $form = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -97,11 +63,7 @@ class DateRangePickerTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DatePickerType'
-                // (when requirement of Symfony is >= 2.8)
-                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Sonata\CoreBundle\Form\Type\DatePickerType'
-                    : 'sonata_type_date_picker',
+                'field_type' => 'Sonata\CoreBundle\Form\Type\DatePickerType',
             ), $options);
     }
 }

--- a/Tests/Form/Type/DateRangeTypeTest.php
+++ b/Tests/Form/Type/DateRangeTypeTest.php
@@ -25,24 +25,8 @@ class DateRangeTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -51,9 +35,7 @@ class DateRangeTypeTest extends TypeTestCase
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
-                : 'date',
+            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\DateType',
         ));
     }
 
@@ -61,25 +43,9 @@ class DateRangeTypeTest extends TypeTestCase
     {
         $form = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -97,11 +63,7 @@ class DateRangeTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\DateType'
-                // (when requirement of Symfony is >= 2.8)
-                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
-                    : 'date',
+                'field_type' => 'Symfony\Component\Form\Extension\Core\Type\DateType',
             ), $options);
     }
 }

--- a/Tests/Form/Type/DateTimePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimePickerTypeTest.php
@@ -27,24 +27,8 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -69,25 +53,9 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
             $this->getMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetName()

--- a/Tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -25,24 +25,8 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -51,9 +35,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
             'field_options' => array(),
             'field_options_start' => array(),
             'field_options_end' => array(),
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
-                : 'sonata_type_datetime_picker',
+            'field_type' => 'Sonata\CoreBundle\Form\Type\DateTimePickerType',
         ));
     }
 
@@ -61,25 +43,9 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
     {
         $form = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -97,11 +63,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
                 'field_options' => array(),
                 'field_options_start' => array(),
                 'field_options_end' => array(),
-                // NEXT_MAJOR: Remove ternary and keep 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
-                // (when requirement of Symfony is >= 2.8)
-                'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Sonata\CoreBundle\Form\Type\DateTimePickerType'
-                    : 'sonata_type_datetime_picker',
+                'field_type' => 'Sonata\CoreBundle\Form\Type\DateTimePickerType',
             ), $options);
     }
 }

--- a/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -90,24 +90,8 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -178,25 +162,9 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             'serialization_api_write'
         );
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     /**

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -25,24 +25,8 @@ class EqualTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -56,25 +40,9 @@ class EqualTypeTest extends TypeTestCase
     {
         $form = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -92,9 +60,7 @@ class EqualTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_equal', $type->getName());
         $this->assertSame(
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-                'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-                'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent()
         );
 
@@ -102,20 +68,16 @@ class EqualTypeTest extends TypeTestCase
 
         $options = $resolver->resolve();
 
-        $choices = array(1 => 'label_type_equals', 2 => 'label_type_not_equals');
-
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-        }
-
         $expected = array(
             'choice_translation_domain' => 'SonataCoreBundle',
             'choices_as_values' => true,
-            'choices' => $choices,
+            'choices' => array(
+                'label_type_equals' => 1,
+                'label_type_not_equals' => 2,
+            ),
         );
 
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')
-            || !method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (!method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             unset($expected['choices_as_values']);
         }
 

--- a/Tests/Form/Type/FormChoiceWidgetTest.php
+++ b/Tests/Form/Type/FormChoiceWidgetTest.php
@@ -99,27 +99,13 @@ class FormChoiceWidgetTest extends AbstractWidgetTestCase
 
     private function getChoiceClass()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
-            'choice';
+        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
     }
 
-    /**
-     * NEXT_MAJOR: Remove this hack when dropping support for symfony 2.6.
-     *
-     * For SF < 2.6, we use 'empty_data' to provide default empty value.
-     * For SF >= 2.6, we must use 'placeholder' to achieve the same.
-     */
     private function getDefaultOption()
     {
-        if (method_exists('Symfony\Component\Form\Tests\AbstractLayoutTest', 'testSingleChoiceNonRequiredWithPlaceholder')) {
-            return array(
-                'placeholder' => 'Choose an option',
-            );
-        }
-
         return array(
-            'empty_value' => 'Choose an option',
+            'placeholder' => 'Choose an option',
         );
     }
 }

--- a/Tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/Tests/Form/Type/ImmutableArrayTypeTest.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Symfony\Component\Form\Test\TypeTestCase;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImmutableArrayTypeTest extends TypeTestCase
@@ -26,24 +25,8 @@ class ImmutableArrayTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -57,25 +40,9 @@ class ImmutableArrayTypeTest extends TypeTestCase
     {
         $form = new ImmutableArrayType();
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -84,7 +51,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_immutable_array', $type->getName());
 
-        $this->assertSame(version_compare(Kernel::VERSION, '2.8', '<') ? 'form' : 'Symfony\Component\Form\Extension\Core\Type\FormType', $type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\FormType', $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
@@ -107,11 +74,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
                 return $name === 'ttl';
             }),
             $this->callback(function ($name) {
-                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                // (when requirement of Symfony is >= 2.8)
-                return $name === method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                    : 'text';
+                return 'Symfony\Component\Form\Extension\Core\Type\TextType';
             }),
             $this->callback(function ($name) {
                 return $name === array(1 => '1');
@@ -122,14 +85,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
         $optionsCallback = function ($builder, $name, $type, $extra) use ($self) {
             $self->assertEquals(array('foo', 'bar'), $extra);
             $self->assertEquals($name, 'ttl');
-            $self->assertEquals(
-                $type,
-                // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                // (when requirement of Symfony is >= 2.8)
-                method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                    : 'text'
-            );
+            $self->assertEquals($type, 'Symfony\Component\Form\Extension\Core\Type\TextType');
             $self->assertInstanceOf('Symfony\Component\Form\Test\FormBuilderInterface', $builder);
 
             return array('1' => '1');
@@ -139,11 +95,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
             'keys' => array(
                 array(
                     'ttl',
-                    // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                    // (when requirement of Symfony is >= 2.8)
-                    method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                        : 'text',
+                    'Symfony\Component\Form\Extension\Core\Type\TextType',
                     $optionsCallback,
                     'foo',
                     'bar',

--- a/Tests/Form/Type/StatusTypeTest.php
+++ b/Tests/Form/Type/StatusTypeTest.php
@@ -38,24 +38,8 @@ class StatusTypeTest extends TypeTestCase
             ->expects($this->any())
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -69,25 +53,9 @@ class StatusTypeTest extends TypeTestCase
     {
         $form = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
 
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $form->getParent();
+        $parentRef = $form->getParent();
 
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     public function testGetDefaultOptions()
@@ -101,11 +69,7 @@ class StatusTypeTest extends TypeTestCase
         $this->assertSame('choice_type', $type->getName());
 
         $this->assertSame(
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent()
         );
 
@@ -128,11 +92,7 @@ class StatusTypeTest extends TypeTestCase
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent()
         );
 
@@ -158,11 +118,7 @@ class StatusTypeTest extends TypeTestCase
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-                : 'choice',
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
             $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/config": "^2.3 || ^3.0",
-        "symfony/form": "^2.3.5 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/property-access": "^2.3 || ^3.0",
-        "symfony/security": "^2.3 || ^3.0",
-        "symfony/translation": "^2.3 || ^3.0",
-        "symfony/twig-bridge": "^2.3.5 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0",
+        "symfony/config": "^2.8 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/http-foundation": "^2.8 || ^3.0",
+        "symfony/property-access": "^2.8 || ^3.0",
+        "symfony/security": "^2.8 || ^3.0",
+        "symfony/translation": "^2.8 || ^3.0",
+        "symfony/twig-bridge": "^2.8 || ^3.0",
+        "symfony/validator": "^2.8 || ^3.0",
         "twig/extensions": "^1.0",
         "twig/twig": "^1.23 || ^2.0"
     },
@@ -39,7 +39,7 @@
         "nelmio/api-doc-bundle": "^2.11",
         "sensio/framework-extra-bundle": "^2.3 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7"
+        "symfony/phpunit-bridge": "^2.8"
     },
     "autoload": {
         "psr-4": { "Sonata\\CoreBundle\\": "" },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a major change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Changed
- Bumped Symfony version to 2.8
```
## To do
- [x] Setup dev-kit https://github.com/sonata-project/dev-kit/pull/154
## Subject

Only the latest LTS release is supported for the next major release.
