### PR TITLE
Bump PHP version to 5.6

### DIFF
--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -20,14 +20,11 @@ class BooleanTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class BooleanTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/CollectionTypeTest.php
+++ b/Tests/Form/Type/CollectionTypeTest.php
@@ -20,14 +20,11 @@ class CollectionTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class CollectionTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -21,14 +21,11 @@ class ColorSelectorTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -45,7 +42,7 @@ class ColorSelectorTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DatePickerTypeTest.php
+++ b/Tests/Form/Type/DatePickerTypeTest.php
@@ -22,14 +22,11 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -46,7 +43,7 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DateRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateRangePickerTypeTest.php
@@ -20,14 +20,11 @@ class DateRangePickerTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class DateRangePickerTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DateRangeTypeTest.php
+++ b/Tests/Form/Type/DateRangeTypeTest.php
@@ -20,14 +20,11 @@ class DateRangeTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class DateRangeTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DateTimePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimePickerTypeTest.php
@@ -22,14 +22,11 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -46,7 +43,7 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -20,14 +20,11 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -85,14 +85,11 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
 
     public function testBuildFormAddCall()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -109,7 +106,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -20,14 +20,11 @@ class EqualTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -44,7 +41,7 @@ class EqualTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/Tests/Form/Type/ImmutableArrayTypeTest.php
@@ -21,14 +21,11 @@ class ImmutableArrayTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -45,7 +42,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/Tests/Form/Type/StatusTypeTest.php
+++ b/Tests/Form/Type/StatusTypeTest.php
@@ -33,14 +33,11 @@ class StatusTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+            ->will($this->returnCallback(function ($name, $type = null) {
                 // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
                 if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
                     if (null !== $type) {
@@ -57,7 +54,7 @@ class StatusTypeTest extends TypeTestCase
                             ;
                         }
 
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
                     }
                 }
             }));

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/config": "^2.3 || ^3.0",
         "symfony/form": "^2.3.5 || ^3.0",
         "symfony/http-foundation": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a major change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Changed
- Bumped php version to 5.6
```
## To do
- [x] Setup dev-kit https://github.com/sonata-project/dev-kit/pull/165
## Subject

Only the active supported php release are supported for the next major release.
