### PR TITLE
better deprecation handling for BasePickerType

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -57,7 +57,7 @@ abstract class BasePickerType extends AbstractType
         if (null === $this->translator) {
             @trigger_error(
                 'Initializing '.__CLASS__.' without TranslatorInterface
-                is deprecated since 2.4 and will be remove in 3.0.',
+                is deprecated since 2.4 and will be remove in 4.0.',
                 E_USER_DEPRECATED
             );
             $this->locale = \Locale::getDefault();

--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -57,7 +57,7 @@ abstract class BasePickerType extends AbstractType
         if (null === $this->translator) {
             @trigger_error(
                 'Initializing '.__CLASS__.' without TranslatorInterface
-                is deprecated since 2.4 and will be remove in 4.0.',
+                is deprecated since 2.4 and will be removed in 4.0.',
                 E_USER_DEPRECATED
             );
             $this->locale = \Locale::getDefault();

--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -21,7 +21,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 /**
  * Class BasePickerType (to factorize DatePickerType and DateTimePickerType code.
  *
- *
  * @author Hugo Briand <briand@ekino.com>
  */
 abstract class BasePickerType extends AbstractType
@@ -35,12 +34,15 @@ abstract class BasePickerType extends AbstractType
      * @var string
      */
     protected $locale;
+
     /**
      * @var MomentFormatConverter
      */
     private $formatConverter;
 
     /**
+     * NEXT_MAJOR: TranslatorInterface needs to be mandatory.
+     *
      * @param MomentFormatConverter $formatConverter
      * @param TranslatorInterface   $translator
      */
@@ -49,11 +51,18 @@ abstract class BasePickerType extends AbstractType
         $this->formatConverter = $formatConverter;
         $this->translator = $translator;
 
-        if (null !== $this->translator) {
-            $this->locale = $this->translator->getLocale();
-        } else {
-            @trigger_error('Initializing '.__CLASS__.' without TranslatorInterface is deprecated since 3.0 and will be removed in 4.0.', E_USER_DEPRECATED);
+        /*
+         * NEXT_MAJOR: remove this check
+         */
+        if (null === $this->translator) {
+            @trigger_error(
+                'Initializing '.__CLASS__.' without TranslatorInterface
+                is deprecated since 2.4 and will be remove in 3.0.',
+                E_USER_DEPRECATED
+            );
             $this->locale = \Locale::getDefault();
+        } else {
+            $this->locale = $this->translator->getLocale();
         }
     }
 
@@ -68,7 +77,14 @@ abstract class BasePickerType extends AbstractType
             $format = $options['date_format'];
         } elseif (is_int($format)) {
             $timeFormat = ($options['dp_pick_time']) ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::NONE;
-            $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $format, $timeFormat, null, \IntlDateFormatter::GREGORIAN, null);
+            $intlDateFormatter = new \IntlDateFormatter(
+                \Locale::getDefault(),
+                $format,
+                $timeFormat,
+                null,
+                \IntlDateFormatter::GREGORIAN,
+                null
+            );
             $format = $intlDateFormatter->getPattern();
         }
 

--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -61,9 +61,11 @@ abstract class BasePickerType extends AbstractType
                 E_USER_DEPRECATED
             );
             $this->locale = \Locale::getDefault();
-        } else {
-            $this->locale = $this->translator->getLocale();
+
+            return;
         }
+
+        $this->locale = $this->translator->getLocale();
     }
 
     /**

--- a/Tests/Form/Type/BasePickerTypeTest.php
+++ b/Tests/Form/Type/BasePickerTypeTest.php
@@ -31,13 +31,18 @@ class BasePickerTest extends BasePickerType
 }
 
 /**
+ * Class BasePickerTypeTest.
+ *
  * @author Hugo Briand <briand@ekino.com>
  */
 class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testFinishView()
     {
-        $type = new BasePickerTest(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new BasePickerTest(
+            new MomentFormatConverter(),
+            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+        );
 
         $view = new FormView();
         $form = new Form($this->getMock('Symfony\Component\Form\FormConfigInterface'));
@@ -56,6 +61,11 @@ class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('text', $view->vars['type']);
     }
 
+    /**
+     * NEXT_MAJOR: remove this test.
+     *
+     * @group legacy
+     */
     public function testLegacyConstructor()
     {
         new BasePickerTest(new MomentFormatConverter());

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -13,3 +13,24 @@ The exporter class and service are now deprecated in favor of very similar equiv
 [`sonata-project/exporter`](https://github.com/sonata-project/exporter) library,
 which are available since version 1.6.0,
 if you enable the bundle as described in the documentation.
+
+### BasePickerType needs a ``TranslatorInterface`` as 2nd argument
+
+Before:
+
+```php
+    /**
+     * @param MomentFormatConverter $formatConverter
+     */
+    public function __construct(MomentFormatConverter $formatConverter)
+```
+
+After:
+
+```php
+    /**
+     * @param MomentFormatConverter $formatConverter
+     * @param TranslatorInterface   $translator
+     */
+    public function __construct(MomentFormatConverter $formatConverter, TranslatorInterface $translator)
+```


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Better deprecation handling

