### PR TITLE
Use choice_translation_domain in BooleanType

### DIFF
--- a/Form/Type/BooleanType.php
+++ b/Form/Type/BooleanType.php
@@ -77,9 +77,11 @@ class BooleanType extends AbstractType
             },
         );
 
-        // SF 2.7+ BC
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.7)
         if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
             $choices = array_flip($choices);
+
+            $defaultOptions['choice_translation_domain'] = 'SonataCoreBundle';
 
             // choice_as_value options is not needed in SF 3.0+
             if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -163,6 +163,7 @@ class BooleanTypeTest extends TypeTestCase
         $expectedOptions = array(
             'transform' => false,
             'catalogue' => 'SonataCoreBundle',
+            'choice_translation_domain' => 'SonataCoreBundle',
             'choices_as_values' => true,
             'translation_domain' => 'fooTrans',
             'choices' => array(1 => 'foo_yes', 2 => 'foo_no'),
@@ -171,6 +172,11 @@ class BooleanTypeTest extends TypeTestCase
         if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')
             || !method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
             unset($expectedOptions['choices_as_values']);
+        }
+
+        // NEXT_MAJOR: Remove this block (when requirement of Symfony is >= 2.7)
+        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            unset($expectedOptions['choice_translation_domain']);
         }
 
         $this->assertSame($expectedOptions, $resolvedOptions);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Use `choice_translation_domain` in `BooleanType`
```

## Subject

When setting the `translation_domain` option in an custom form, only the label should get affected. The `yes` and `no` labels should stay.