### PR TITLE
Update outdated doc on form_types.rst

### DIFF
--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -387,9 +387,8 @@ In order to use them, you'll need to perform a bit of setup:
         # app/config/config.yml
 
         twig:
-            form:
-                resources:
-                    - 'SonataCoreBundle:Form:datepicker.html.twig'
+            form_themes:
+                - 'SonataCoreBundle:Form:datepicker.html.twig'
 
 In your layout, you'll need to add the assets dependencies (feel free to adapt this to your needs, for instance to use with assetic):
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this PR is a documentation fix and does not require any BC-break.

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Updated outdated documentation on twig form resources.
```

## Subject

<!-- Describe your Pull Request content here -->

Updated the config bit on datepicker doc to comply with the new twig syntax form_theme https://symfony.com/doc/current/reference/configuration/twig.html