### PR TITLE
Incorrect day of week format for MomentFormat

### DIFF
--- a/Date/MomentFormatConverter.php
+++ b/Date/MomentFormatConverter.php
@@ -43,7 +43,7 @@ class MomentFormatConverter
         // second
         // 'ss'=>'ss', 's'=>'s',
         // day of week
-        'EE' => 'ddd', 'EEEEEE' => 'dd',
+        'EEEEEE' => 'dd', 'EEEE' => 'dddd', 'EE' => 'ddd',
         // timezone
         'ZZZZZ' => 'Z', 'ZZZ' => 'ZZ',
     );

--- a/Tests/Date/MomentFormatConverterTest.php
+++ b/Tests/Date/MomentFormatConverterTest.php
@@ -61,6 +61,9 @@ class MomentFormatConverterTest extends \PHPUnit_Framework_TestCase
         $phpFormat = 'EE, dd/MM/yyyy HH:mm';
         $this->assertSame('ddd, DD/MM/YYYY HH:mm', $mfc->convert($phpFormat));
 
+        $phpFormat = 'EEEE d MMMM y HH:mm';
+        $this->assertSame('dddd D MMMM YYYY HH:mm', $mfc->convert($phpFormat));
+
         $phpFormat = 'dd-MM-yyyy';
         $this->assertSame('DD-MM-YYYY', $mfc->convert($phpFormat));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

I am targetting this branch, because this is a patch for a small issue with the moment format converter.

Closes: Not an existing issue yet, I just found this issue.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Incorrect day of week format for MomentFormat 
```

## Subject
When using the DatePickerType with moment + full date format, you will see an incorrect date format in the attribute `data-date-format`.

Current situation:

```
Format: 'EE' => 'ddd', 'EEEEEE' => 'dd',
Result: \IntlDateFormatter::FULL => dddddd D MMMM YYYY
```

New situation:

```
Proposed format: 'EEEEEE' => 'dd', 'EEEE' => 'dddd', 'EE' => 'ddd',
Result: \IntlDateFormatter::FULL => dddd D MMMM YYYY
```