### PR TITLE
Allow Twig 2.0

### DIFF
--- a/Test/AbstractWidgetTestCase.php
+++ b/Test/AbstractWidgetTestCase.php
@@ -44,6 +44,10 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
      */
     protected function setUp()
     {
+        // NEXT_MAJOR: remove this block when dropping symfony < 2.7 support
+        if (!class_exists('Symfony\Bridge\Twig\Extension\AssetExtension')) {
+            $this->markTestSkipped();
+        }
         parent::setUp();
 
         // NEXT_MAJOR: Remove BC hack when dropping symfony 2.4 support

--- a/Tests/Twig/Node/TemplateBoxNodeTest.php
+++ b/Tests/Twig/Node/TemplateBoxNodeTest.php
@@ -31,7 +31,14 @@ class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
             'sonata_template_box'
         );
 
-        $this->assertSame(1, $body->getLine());
+        // Remove this when dropping twig/twig < 2.0
+        if (!method_exists($body, 'getTemplateLine')) {
+            $this->assertSame(1, $body->getLine());
+
+            return;
+        }
+
+        $this->assertSame(1, $body->getTemplateLine());
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/twig-bridge": "^2.3.5 || ^3.0",
         "symfony/validator": "^2.3 || ^3.0",
         "twig/extensions": "^1.0",
-        "twig/twig": "^1.23"
+        "twig/twig": "^1.23 || ^2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
I am targetting this branch, because this is BC.

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Twig 2.0 compatibility
```

## Subject

Twig 2.0 is out, let's allow it.
