### PR TITLE
Added missing datepicker options

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -142,6 +142,9 @@ abstract class BasePickerType extends AbstractType
             'dp_use_strict' => false,
             'dp_side_by_side' => false,
             'dp_days_of_week_disabled' => array(),
+            'dp_collapse' => true,
+            'dp_calendar_weeks' => false,
+            'dp_view_mode' => 'days',
         );
     }
 }

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -442,6 +442,9 @@ Many of the `standard date picker options`_ are available by adding options with
                         'dp_side_by_side'       => true,
                         'dp_use_current'        => false,
                         'dp_use_seconds'        => false,
+                        'dp_collapse'           => true,
+                        'dp_calendar_weeks'     => false,
+                        'dp_view_mode'          => 'days',
                 ))
 
                 // or sonata_type_date_picker if you don't need the time


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes are backwards compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #373

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Missing bootstrap datepicker options (`dp_collapse`, `dp_calendar_weeks`, `dp_view_mode`)
