### PR TITLE
Fixed a typo in BasePickerType

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -90,7 +90,7 @@ abstract class BasePickerType extends AbstractType
             $format = $intlDateFormatter->getPattern();
         }
 
-        // use seconds if it's allowe in format
+        // use seconds if it's allowed in format
         $options['dp_use_seconds'] = strpos($format, 's') !== false;
 
         $view->vars['moment_format'] = $this->formatConverter->convert($format);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a typo

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

