### PR TITLE
added versions for @deprecated PHPDoc tag

### DIFF
--- a/Component/NativeSlugify.php
+++ b/Component/NativeSlugify.php
@@ -18,7 +18,7 @@ namespace Sonata\CoreBundle\Component;
  *
  * NEXT_MAJOR: remove this class.
  *
- * @deprecated
+ * @deprecated since 2.3, to be removed in 4.0.
  *
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
  */
@@ -29,7 +29,7 @@ class NativeSlugify
      *
      * @return mixed|string
      *
-     * @deprecated
+     * @deprecated since 2.3, to be removed in 4.0.
      */
     public function slugify($text)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.
