### PR TITLE
added dependency for Sonata\CoreBundle\ModelPageableManagerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "cocur/slugify": "^1.4 || ^2.0",
+        "sonata-project/datagrid-bundle": "^2.0",
         "symfony/config": "^2.3 || ^3.0",
         "symfony/form": "^2.3.5 || ^3.0",
         "symfony/http-foundation": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `sonata-project/datagrid-bundle` dependency for `Sonata\CoreBundle\ModelPageableManagerInterface`
```

## Subject

<!-- Describe your Pull Request content here -->

IMO the direct dependency was missing

![screenshot 2017-02-02 09 30 01](https://cloud.githubusercontent.com/assets/995707/22542103/6e079b66-e92a-11e6-9820-826d88ea2db3.png)

