### PR TITLE
Removed deprecated getMock in unit tests

### DIFF
--- a/Test/AbstractWidgetTestCase.php
+++ b/Test/AbstractWidgetTestCase.php
@@ -58,7 +58,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
             'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface',
         ), 'interface_exists');
 
-        $this->renderer = new TwigRenderer($this->getRenderingEngine(), $this->getMock(current($csrfProviderClasses)));
+        $this->renderer = new TwigRenderer($this->getRenderingEngine(), $this->createMock(current($csrfProviderClasses)));
 
         $this->extension = new FormExtension($this->renderer);
         $environment = $this->getEnvironment();
@@ -171,5 +171,21 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         return preg_replace_callback('~<([A-Z0-9]+) \K(.*?)>~i', function ($m) {
             return preg_replace('~\s*~', '', $m[0]);
         }, $html);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method when dropping support for < PHPUnit 5.4.
+     *
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
     }
 }

--- a/Tests/Component/NativeSlugifyTest.php
+++ b/Tests/Component/NativeSlugifyTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\CoreBundle\Tests\Component;
 
 use Sonata\CoreBundle\Component\NativeSlugify;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * @group legacy
  */
-class NativeSlugifyTest extends \PHPUnit_Framework_TestCase
+class NativeSlugifyTest extends PHPUnit_Framework_TestCase
 {
     public function testSlugify()
     {

--- a/Tests/Date/MomentFormatConverterTest.php
+++ b/Tests/Date/MomentFormatConverterTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\CoreBundle\Tests\Date;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MomentFormatConverterTest extends \PHPUnit_Framework_TestCase
+class MomentFormatConverterTest extends PHPUnit_Framework_TestCase
 {
     public function testPhpToMoment()
     {

--- a/Tests/Exporter/ExporterTest.php
+++ b/Tests/Exporter/ExporterTest.php
@@ -13,20 +13,21 @@ namespace Sonata\CoreBundle\Tests\Exporter;
 
 use Exporter\Source\ArraySourceIterator;
 use Sonata\CoreBundle\Exporter\Exporter;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * NEXT_MAJOR: remove this class.
  *
  * @group legacy
  */
-class ExporterTest extends \PHPUnit_Framework_TestCase
+class ExporterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \RuntimeException
      */
     public function testFilter()
     {
-        $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $source = $this->createMock('Exporter\Source\SourceIteratorInterface');
 
         $exporter = new Exporter();
         $exporter->getResponse('foo', 'foo', $source);

--- a/Tests/FlashMessage/FlashManagerTest.php
+++ b/Tests/FlashMessage/FlashManagerTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Tests\FlashMessage;
 
 use Sonata\CoreBundle\FlashMessage\FlashManager;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -23,7 +24,7 @@ use Symfony\Component\Translation\Translator;
 /**
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class FlashManagerTest extends \PHPUnit_Framework_TestCase
+class FlashManagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var SessionInterface

--- a/Tests/Form/DataTransformer/BooleanTypeToBooleanTransformerTest.php
+++ b/Tests/Form/DataTransformer/BooleanTypeToBooleanTransformerTest.php
@@ -13,8 +13,9 @@ namespace Sonata\CoreBundle\Tests\Form\DataTransformer;
 
 use Sonata\CoreBundle\Form\DataTransformer\BooleanTypeToBooleanTransformer;
 use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BooleanTypeToBooleanTransformerTest extends \PHPUnit_Framework_TestCase
+class BooleanTypeToBooleanTransformerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getReverseTransformData

--- a/Tests/Form/EventListener/FixCheckboxDataListenerTest.php
+++ b/Tests/Form/EventListener/FixCheckboxDataListenerTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\CoreBundle\Tests\Form\EventListener;
 
 use Sonata\CoreBundle\Form\EventListener\FixCheckboxDataListener;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Forms;
 
-class FixCheckboxDataListenerTest extends \PHPUnit_Framework_TestCase
+class FixCheckboxDataListenerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider valuesProvider

--- a/Tests/Form/EventListener/ResizeFormListenerTest.php
+++ b/Tests/Form/EventListener/ResizeFormListenerTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\CoreBundle\Tests\Form\EventListener;
 
 use Sonata\CoreBundle\Form\EventListener\ResizeFormListener;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
+class ResizeFormListenerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetSubscribedEvents()
     {

--- a/Tests/Form/Extension/DependencyInjectionExtensionTest.php
+++ b/Tests/Form/Extension/DependencyInjectionExtensionTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\CoreBundle\Tests\Form\Extension;
 
 use Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
-class DependencyInjectionExtensionTest extends \PHPUnit_Framework_TestCase
+class DependencyInjectionExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testValidType()
     {
-        $type = $this->getMock('Symfony\Component\Form\FormTypeInterface');
+        $type = $this->createMock('Symfony\Component\Form\FormTypeInterface');
 
         if (Kernel::MAJOR_VERSION < 3) {
             $type->expects($this->any())
@@ -26,7 +27,7 @@ class DependencyInjectionExtensionTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue('Symfony\Component\Form\Type\FormType'));
         }
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('has')->will($this->returnValue(true));
         $container->expects($this->any())
             ->method('get')
@@ -52,7 +53,7 @@ class DependencyInjectionExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testTypeWithoutService()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $f = new DependencyInjectionExtension($container, array(), array(), array(), array());
 
@@ -61,7 +62,7 @@ class DependencyInjectionExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testTypeExtensionsValid()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('has')->will($this->returnValue(true));
         $container->expects($this->any())
             ->method('get')

--- a/Tests/Form/FormHelperTest.php
+++ b/Tests/Form/FormHelperTest.php
@@ -12,22 +12,23 @@
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Form;
 
-class FormHelperTest extends \PHPUnit_Framework_TestCase
+class FormHelperTest extends PHPUnit_Framework_TestCase
 {
     public function testRemoveFields()
     {
-        $dataMapper = $this->getMock('Symfony\Component\Form\DataMapperInterface');
+        $dataMapper = $this->createMock('Symfony\Component\Form\DataMapperInterface');
 
-        $config = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $config = $this->createMock('Symfony\Component\Form\FormConfigInterface');
         $config->expects($this->any())->method('getName')->will($this->returnValue('root'));
         $config->expects($this->any())->method('getCompound')->will($this->returnValue(true));
         $config->expects($this->any())->method('getDataMapper')->will($this->returnValue($dataMapper));
 
         $form = new Form($config);
 
-        $config = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $config = $this->createMock('Symfony\Component\Form\FormConfigInterface');
         $config->expects($this->any())->method('getName')->will($this->returnValue('child'));
 
         $form->add(new Form($config));

--- a/Tests/Form/Type/BasePickerTypeTest.php
+++ b/Tests/Form/Type/BasePickerTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\BasePickerType;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
@@ -33,17 +34,17 @@ class BasePickerTest extends BasePickerType
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class BasePickerTypeTest extends \PHPUnit_Framework_TestCase
+class BasePickerTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFinishView()
     {
         $type = new BasePickerTest(
             new MomentFormatConverter(),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
         $view = new FormView();
-        $form = new Form($this->getMock('Symfony\Component\Form\FormConfigInterface'));
+        $form = new Form($this->createMock('Symfony\Component\Form\FormConfigInterface'));
 
         $type->finishView($view, $form, array('format' => 'yyyy-MM-dd'));
 

--- a/Tests/Form/Type/BooleanTypeTest.php
+++ b/Tests/Form/Type/BooleanTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\BooleanType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -121,7 +120,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, $optionResolver->resolve(array(
@@ -138,7 +137,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $builder->expects($this->never())->method('addModelTransformer');
 
         $type->buildForm($builder, $optionResolver->resolve(array()));
@@ -150,7 +149,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $builder->expects($this->never())->method('addModelTransformer');
 
         $resolvedOptions = $optionResolver->resolve(array(
@@ -188,7 +187,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $builder->expects($this->never())->method('addModelTransformer');
 
         $resolvedOptions = $optionResolver->resolve(array(

--- a/Tests/Form/Type/CollectionTypeTest.php
+++ b/Tests/Form/Type/CollectionTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\CollectionType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CollectionTypeTest extends TypeTestCase

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Color\Colors;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ColorSelectorType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ColorSelectorTypeTest extends TypeTestCase

--- a/Tests/Form/Type/DatePickerTypeTest.php
+++ b/Tests/Form/Type/DatePickerTypeTest.php
@@ -13,12 +13,13 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DatePickerType;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
+class DatePickerTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testBuildForm()
     {
@@ -52,8 +53,8 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
             }));
 
         $type = new DatePickerType(
-            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
         $type->buildForm($formBuilder, array(
             'dp_pick_time' => false,
@@ -64,8 +65,8 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
     public function testGetParent()
     {
         $form = new DatePickerType(
-            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
@@ -91,7 +92,7 @@ class DatePickerTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testGetName()
     {
-        $type = new DatePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DatePickerType(new MomentFormatConverter(), $this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertSame('sonata_type_date_picker', $type->getName());
     }

--- a/Tests/Form/Type/DateRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateRangePickerTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DateRangePickerType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateRangePickerTypeTest extends TypeTestCase
@@ -49,7 +48,7 @@ class DateRangePickerTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
         $type->buildForm($formBuilder, array(
             'field_options' => array(),
             'field_options_start' => array(),
@@ -62,7 +61,7 @@ class DateRangePickerTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -87,7 +86,7 @@ class DateRangePickerTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertSame('sonata_type_date_range_picker', $type->getName());
 

--- a/Tests/Form/Type/DateRangeTypeTest.php
+++ b/Tests/Form/Type/DateRangeTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DateRangeType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateRangeTypeTest extends TypeTestCase
@@ -49,7 +48,7 @@ class DateRangeTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
         $type->buildForm($formBuilder, array(
             'field_options' => array(),
             'field_options_start' => array(),
@@ -62,7 +61,7 @@ class DateRangeTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -87,7 +86,7 @@ class DateRangeTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateRangeType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertSame('sonata_type_date_range', $type->getName());
 

--- a/Tests/Form/Type/DateTimePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimePickerTypeTest.php
@@ -13,12 +13,13 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
+class DateTimePickerTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testBuildForm()
     {
@@ -52,8 +53,8 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
             }));
 
         $type = new DateTimePickerType(
-            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
         $type->buildForm($formBuilder, array(
@@ -68,8 +69,8 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
     public function testGetParent()
     {
         $form = new DateTimePickerType(
-            $this->getMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->getMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
+            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
         );
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
@@ -95,7 +96,7 @@ class DateTimePickerTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testGetName()
     {
-        $type = new DateTimePickerType(new MomentFormatConverter(), $this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimePickerType(new MomentFormatConverter(), $this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertSame('sonata_type_datetime_picker', $type->getName());
     }

--- a/Tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/Tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateTimeRangePickerTypeTest extends TypeTestCase
@@ -49,7 +48,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
         $type->buildForm($formBuilder, array(
             'field_options' => array(),
             'field_options_start' => array(),
@@ -62,7 +61,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -87,7 +86,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateTimeRangePickerType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         $this->assertSame('sonata_type_datetime_range_picker', $type->getName());
 

--- a/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/Tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -16,7 +16,6 @@ use JMS\Serializer\Metadata\ClassMetadata as SerializerMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
 use Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
 class FakeMetadataClass
@@ -115,7 +114,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             }));
 
         $type = new DoctrineORMSerializationType(
-            $this->getMetadataFactoryMock(), // $this->getMock('Metadata\MetadataFactoryInterface'),
+            $this->getMetadataFactoryMock(), // $this->createMock('Metadata\MetadataFactoryInterface'),
             $this->getRegistryMock(),
             'form_type_test',
             $this->class,
@@ -174,8 +173,8 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $form = new DoctrineORMSerializationType(
-            $this->getMock('Metadata\MetadataFactoryInterface'),
-            $this->getMock('Doctrine\Common\Persistence\ManagerRegistry'),
+            $this->createMock('Metadata\MetadataFactoryInterface'),
+            $this->createMock('Doctrine\Common\Persistence\ManagerRegistry'),
             'form_type_test',
             $this->class,
             'serialization_api_write'
@@ -223,7 +222,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
         $classMetadata->addPropertyMetadata($url);
         $classMetadata->addPropertyMetadata($comments);
 
-        $metadataFactory = $this->getMock('Metadata\MetadataFactoryInterface');
+        $metadataFactory = $this->createMock('Metadata\MetadataFactoryInterface');
         $metadataFactory->expects($this->once())->method('getMetadataForClass')->will($this->returnValue($classMetadata));
 
         return $metadataFactory;
@@ -254,10 +253,10 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             ),
         );
 
-        $entityManager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $entityManager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $entityManager->expects($this->once())->method('getClassMetadata')->will($this->returnValue($classMetadata));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($entityManager));
 
         return $registry;

--- a/Tests/Form/Type/EqualTypeTest.php
+++ b/Tests/Form/Type/EqualTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\EqualType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EqualTypeTest extends TypeTestCase
@@ -49,7 +48,7 @@ class EqualTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new EqualType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
         $type->buildForm($formBuilder, array(
             'choices' => array(),
         ));
@@ -57,7 +56,7 @@ class EqualTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new EqualType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new EqualType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -82,7 +81,7 @@ class EqualTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $mock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $mock = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $mock->expects($this->exactly(0))
             ->method('trans')

--- a/Tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/Tests/Form/Type/ImmutableArrayTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -104,7 +103,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
     {
         $type = new ImmutableArrayType();
 
-        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
         $builder->expects($this->once())->method('add')->with(
             $this->callback(function ($name) {
                 return $name === 'ttl';

--- a/Tests/Form/Type/StatusTypeTest.php
+++ b/Tests/Form/Type/StatusTypeTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class Choice

--- a/Tests/Form/Type/TranslatableChoiceTypeTest.php
+++ b/Tests/Form/Type/TranslatableChoiceTypeTest.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -52,7 +51,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new TranslatableChoiceType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new TranslatableChoiceType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
         $type->buildForm($formBuilder, array(
             'catalogue' => 'messages',
         ));
@@ -60,7 +59,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new TranslatableChoiceType($this->getMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new TranslatableChoiceType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -85,7 +84,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 
     public function testLegacyGetDefaultOptions()
     {
-        $stub = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $stub = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $type = new TranslatableChoiceType($stub);
 

--- a/Tests/Form/Type/TypeTestCase.php
+++ b/Tests/Form/Type/TypeTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Form\Type;
+
+/**
+ * NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @internal
+ */
+class TypeTestCase extends \Symfony\Component\Form\Test\TypeTestCase
+{
+    /**
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
+    }
+}

--- a/Tests/Model/Adapter/AdapterChainTest.php
+++ b/Tests/Model/Adapter/AdapterChainTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
 use Sonata\CoreBundle\Model\Adapter\AdapterChain;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
-class AdapterChainTest extends \PHPUnit_Framework_TestCase
+class AdapterChainTest extends PHPUnit_Framework_TestCase
 {
     public function testEmptyAdapter()
     {
@@ -27,10 +28,10 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new AdapterChain();
 
-        $adapter->addAdapter($fake1 = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake1 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
         $fake1->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue(null));
 
-        $adapter->addAdapter($fake2 = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake2 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
 
         $fake2->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue('voila'));
 
@@ -41,10 +42,10 @@ class AdapterChainTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new AdapterChain();
 
-        $adapter->addAdapter($fake1 = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake1 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
         $fake1->expects($this->once())->method('getNormalizedIdentifier')->will($this->returnValue(null));
 
-        $adapter->addAdapter($fake2 = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake2 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
 
         $fake2->expects($this->once())->method('getNormalizedIdentifier')->will($this->returnValue('voila'));
 

--- a/Tests/Model/Adapter/DoctrineORMAdapterTest.php
+++ b/Tests/Model/Adapter/DoctrineORMAdapterTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
 use Sonata\CoreBundle\Model\Adapter\DoctrineORMAdapter;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
-class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
+class DoctrineORMAdapterTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -27,7 +28,7 @@ class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizedIdentifierWithScalar()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $adapter = new DoctrineORMAdapter($registry);
 
         $adapter->getNormalizedIdentifier(1);
@@ -35,7 +36,7 @@ class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizedIdentifierWithNull()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $adapter = new DoctrineORMAdapter($registry);
 
         $this->assertNull($adapter->getNormalizedIdentifier(null));
@@ -43,7 +44,7 @@ class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizedIdentifierWithNoManager()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $adapter = new DoctrineORMAdapter($registry);
@@ -56,10 +57,10 @@ class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
         $unitOfWork = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')->disableOriginalConstructor()->getMock();
         $unitOfWork->expects($this->once())->method('isInIdentityMap')->will($this->returnValue(false));
 
-        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $manager->expects($this->any())->method('getUnitOfWork')->will($this->returnValue($unitOfWork));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrineORMAdapter($registry);
@@ -76,10 +77,10 @@ class DoctrineORMAdapterTest extends \PHPUnit_Framework_TestCase
         $unitOfWork->expects($this->once())->method('isInIdentityMap')->will($this->returnValue(true));
         $unitOfWork->expects($this->once())->method('getEntityIdentifier')->will($this->returnValue($data));
 
-        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $manager->expects($this->any())->method('getUnitOfWork')->will($this->returnValue($unitOfWork));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrineORMAdapter($registry);

--- a/Tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
+++ b/Tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
@@ -13,13 +13,14 @@ namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Sonata\CoreBundle\Model\Adapter\DoctrinePHPCRAdapter;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 class MyDocument
 {
     public $path;
 }
 
-class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
+class DoctrinePHPCRAdapterTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -33,7 +34,7 @@ class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizedIdentifierWithScalar()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $adapter = new DoctrinePHPCRAdapter($registry);
 
         $adapter->getNormalizedIdentifier(1);
@@ -41,7 +42,7 @@ class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizedIdentifierWithNull()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $adapter = new DoctrinePHPCRAdapter($registry);
 
         $this->assertNull($adapter->getNormalizedIdentifier(null));
@@ -49,7 +50,7 @@ class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizedIdentifierWithNoManager()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $adapter = new DoctrinePHPCRAdapter($registry);
@@ -62,7 +63,7 @@ class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
         $manager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
         $manager->expects($this->once())->method('contains')->will($this->returnValue(false));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrinePHPCRAdapter($registry);
@@ -83,7 +84,7 @@ class DoctrinePHPCRAdapterTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->any())->method('contains')->will($this->returnValue(true));
         $manager->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrinePHPCRAdapter($registry);

--- a/Tests/Model/BaseDocumentManagerTest.php
+++ b/Tests/Model/BaseDocumentManagerTest.php
@@ -12,16 +12,17 @@
 namespace Sonata\CoreBundle\Tests\Entity;
 
 use Sonata\CoreBundle\Model\BaseDocumentManager;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 class DocumentManager extends BaseDocumentManager
 {
 }
 
-class BaseDocumentManagerTest extends \PHPUnit_Framework_TestCase
+class BaseDocumentManagerTest extends PHPUnit_Framework_TestCase
 {
     public function getManager()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
 
         $manager = new DocumentManager('classname', $registry);
 

--- a/Tests/Model/BaseEntityManagerTest.php
+++ b/Tests/Model/BaseEntityManagerTest.php
@@ -12,16 +12,17 @@
 namespace Sonata\CoreBundle\Tests\Entity;
 
 use Sonata\CoreBundle\Model\BaseEntityManager;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 class EntityManager extends BaseEntityManager
 {
 }
 
-class BaseEntityManagerTest extends \PHPUnit_Framework_TestCase
+class BaseEntityManagerTest extends PHPUnit_Framework_TestCase
 {
     public function getManager()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
 
         $manager = new EntityManager('classname', $registry);
 
@@ -48,7 +49,7 @@ class BaseEntityManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionOnNonMappedEntity()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $manager = new EntityManager('classname', $registry);
@@ -57,9 +58,9 @@ class BaseEntityManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetEntityManager()
     {
-        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($objectManager));
 
         $manager = new EntityManager('classname', $registry);

--- a/Tests/Model/BaseManagerTest.php
+++ b/Tests/Model/BaseManagerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Model;
 
 use Doctrine\DBAL\Connection;
 use Sonata\CoreBundle\Model\BaseManager;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 class ManagerTest extends BaseManager
 {
@@ -38,7 +39,7 @@ class ManagerTest extends BaseManager
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class BaseManagerTest extends \PHPUnit_Framework_TestCase
+class BaseManagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
@@ -46,7 +47,7 @@ class BaseManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckObject()
     {
-        $manager = new ManagerTest('class', $this->getMock('Doctrine\Common\Persistence\ManagerRegistry'));
+        $manager = new ManagerTest('class', $this->createMock('Doctrine\Common\Persistence\ManagerRegistry'));
 
         $manager->publicCheckObject(new \DateTime());
     }

--- a/Tests/Model/MetadataTest.php
+++ b/Tests/Model/MetadataTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\CoreBundle\Tests\Model;
 
 use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends PHPUnit_Framework_TestCase
 {
     public function testGetters()
     {

--- a/Tests/PHPUnit_Framework_TestCase.php
+++ b/Tests/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests;
+
+/**
+ * NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @internal
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
+    }
+}

--- a/Tests/Serializer/BaseSerializerHandlerTest.php
+++ b/Tests/Serializer/BaseSerializerHandlerTest.php
@@ -13,11 +13,12 @@ namespace Sonata\CoreBundle\Tests\Serializer;
 
 use JMS\Serializer\GraphNavigator;
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
+final class BaseSerializerHandlerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @group legacy
@@ -26,7 +27,7 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSubscribingMethodsWithDefaultFormats()
     {
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
 
         $serializer = new FooSerializer($manager);
 
@@ -76,7 +77,7 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetFormats()
     {
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
 
         $serializer = new FooSerializer($manager);
 
@@ -104,7 +105,7 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testAddFormats()
     {
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
 
         $serializer = new FooSerializer($manager);
 
@@ -146,26 +147,23 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeObjectToIdWithDataIsInstanceOfManager()
     {
-        $modelInstance = $this->getMock(
-            'Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer',
-            array('getId'),
-            array(),
-            '',
-            false
-        );
+        $modelInstance = $this->getMockBuilder('Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getId'))
+            ->getMock();
 
         $modelInstance->expects($this->once())
             ->method('getId')
             ->willReturn(1);
 
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
         $manager->expects($this->once())
             ->method('getClass')
             ->willReturn(get_class($modelInstance));
 
-        $context = $this->getMock('JMS\Serializer\Context');
+        $context = $this->createMock('JMS\Serializer\Context');
 
-        $visitor = $this->getMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
         $visitor->expects($this->once())
             ->method('visitInteger')
             ->with(1, array('foo'), $context)
@@ -178,22 +176,18 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testSerializeObjectToIdWithDataIsNotInstanceOfManager()
     {
-        $modelInstance = $this->getMock(
-            'Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $modelInstance = $this->getMockBuilder('Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
         $manager->expects($this->once())
             ->method('getClass')
             ->willReturn('bar');
 
-        $context = $this->getMock('JMS\Serializer\Context');
+        $context = $this->createMock('JMS\Serializer\Context');
 
-        $visitor = $this->getMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
         $visitor->expects($this->never())
             ->method('visitInteger');
 
@@ -204,13 +198,13 @@ final class BaseSerializerHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeserializeObjectFromId()
     {
-        $manager = $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
         $manager->expects($this->once())
             ->method('findOneBy')
             ->with(array('id' => 'foo'))
             ->willReturn('bar');
 
-        $visitor = $this->getMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
 
         $serializer = new FooSerializer($manager);
 

--- a/Tests/SonataCoreBundleTest.php
+++ b/Tests/SonataCoreBundleTest.php
@@ -21,14 +21,13 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-final class SonataCoreBundleTest extends \PHPUnit_Framework_TestCase
+final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
 {
     public function testBuild()
     {
-        $containerBuilder = $this->getMock(
-            'Symfony\Component\DependencyInjection\ContainerBuilder',
-            array('addCompilerPass')
-        );
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('addCompilerPass'))
+            ->getMock();
 
         $containerBuilder->expects($this->exactly(3))
             ->method('addCompilerPass')
@@ -162,7 +161,7 @@ final class SonataCoreBundleTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new SonataCoreBundle();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $container->expects($this->once())
             ->method('hasParameter')

--- a/Tests/Twig/Extension/FormTypeExtensionTest.php
+++ b/Tests/Twig/Extension/FormTypeExtensionTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Twig\Extension\FormTypeExtension;
 
-class FormTypeExtensionTest extends \PHPUnit_Framework_TestCase
+class FormTypeExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testGetName()
     {

--- a/Tests/Twig/Extension/StatusExtensionTest.php
+++ b/Tests/Twig/Extension/StatusExtensionTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Twig\Extension\StatusExtension;
 
-class StatusExtensionTest extends \PHPUnit_Framework_TestCase
+class StatusExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testGetName()
     {

--- a/Tests/Twig/Extension/TemplateExtensionTest.php
+++ b/Tests/Twig/Extension/TemplateExtensionTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Twig\Extension\TemplateExtension;
 
-class TemplateExtensionTest extends \PHPUnit_Framework_TestCase
+class TemplateExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @group legacy
@@ -23,9 +24,9 @@ class TemplateExtensionTest extends \PHPUnit_Framework_TestCase
         setlocale(LC_ALL, 'en_US.utf8');
         setlocale(LC_CTYPE, 'en_US.utf8');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
-        $adapter = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
+        $adapter = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
         $adapter->expects($this->never())->method('getUrlsafeIdentifier');
 
         $extension = new TemplateExtension(true, $translator, $adapter);
@@ -40,9 +41,9 @@ class TemplateExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testSafeUrl()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
-        $adapter = $this->getMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
+        $adapter = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
         $adapter->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue('safe-parameter'));
 
         $extension = new TemplateExtension(true, $translator, $adapter);

--- a/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
+++ b/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\CoreBundle\Tests\Twig\TokenParser;
 
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
 
-class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
+class TemplateBoxTokenParserTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getTestsForRender
@@ -27,7 +28,7 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testCompile($enabled, $source, $expected)
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $env = new \Twig_Environment(new \Twig_Loader_Array(array()), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
         $env->addTokenParser(new TemplateBoxTokenParser($enabled, $translator));
@@ -51,7 +52,7 @@ class TemplateBoxTokenParserTest extends \PHPUnit_Framework_TestCase
 
     public function getTestsForRender()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         return array(
             array(

--- a/Tests/Validator/Constraints/InlineConstraintTest.php
+++ b/Tests/Validator/Constraints/InlineConstraintTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\CoreBundle\Test\Validator\Constraints;
 
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Validator\Constraints\InlineConstraint;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class InlineConstraintTest extends \PHPUnit_Framework_TestCase
+class InlineConstraintTest extends PHPUnit_Framework_TestCase
 {
     public function testValidatedBy()
     {

--- a/Tests/Validator/ErrorElementTest.php
+++ b/Tests/Validator/ErrorElementTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Tests\Validator;
 
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Entity\Foo;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -20,7 +21,7 @@ use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionCont
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class ErrorElementTest extends \PHPUnit_Framework_TestCase
+class ErrorElementTest extends PHPUnit_Framework_TestCase
 {
     private $errorElement;
     private $context;
@@ -29,15 +30,15 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $constraintValidatorFactory = $this->getMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
+        $constraintValidatorFactory = $this->createMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
 
-        $this->context = $this->getMock(interface_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ? 'Symfony\Component\Validator\Context\ExecutionContextInterface' : 'Symfony\Component\Validator\ExecutionContextInterface');
+        $this->context = $this->createMock(interface_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ? 'Symfony\Component\Validator\Context\ExecutionContextInterface' : 'Symfony\Component\Validator\ExecutionContextInterface');
         $this->context->expects($this->once())
                 ->method('getPropertyPath')
                 ->will($this->returnValue('bar'));
 
         if ($this->context instanceof ExecutionContextInterface) {
-            $builder = $this->getMock('Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+            $builder = $this->createMock('Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
             $builder->expects($this->any())
                 ->method($this->anything())
                 ->will($this->returnSelf());
@@ -46,9 +47,9 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
                 ->method('buildViolation')
                 ->willReturn($builder);
 
-            $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
 
-            $this->contextualValidator = $this->getMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+            $this->contextualValidator = $this->createMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
             $this->contextualValidator->expects($this->any())
                 ->method($this->anything())
                 ->will($this->returnSelf());
@@ -198,7 +199,7 @@ class ErrorElementTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionIsThrownWhenContextIsString()
     {
-        $constraintValidatorFactory = $this->getMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
+        $constraintValidatorFactory = $this->createMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
 
         $this->setExpectedException(
             'InvalidArgumentException',

--- a/Tests/Validator/InlineValidatorTest.php
+++ b/Tests/Validator/InlineValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Tests\Validator;
 
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Validator\FooValidatorService;
+use Sonata\CoreBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Validator\InlineValidator;
 use Symfony\Component\Validator\Exception\ValidatorException;
@@ -19,7 +20,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-final class InlineValidatorTest extends \PHPUnit_Framework_TestCase
+final class InlineValidatorTest extends PHPUnit_Framework_TestCase
 {
     private $container;
     private $constraintValidatorFactory;
@@ -27,11 +28,11 @@ final class InlineValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->constraintValidatorFactory = $this->getMock(
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->constraintValidatorFactory = $this->createMock(
             'Symfony\Component\Validator\ConstraintValidatorFactoryInterface'
         );
-        $this->context = $this->getMock(
+        $this->context = $this->createMock(
             interface_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ?
                 'Symfony\Component\Validator\Context\ExecutionContextInterface' :
                 'Symfony\Component\Validator\ExecutionContextInterface'
@@ -58,7 +59,9 @@ final class InlineValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\Validator\Exception\ValidatorException', 'foo is equal to foo');
 
-        $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array('isClosure', 'getClosure'));
+        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+            ->setMethods(array('isClosure', 'getClosure'))
+            ->getMock();
 
         $constraint->expects($this->once())
             ->method('isClosure')
@@ -79,11 +82,13 @@ final class InlineValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateWithConstraintGetServiceIsString()
     {
-        $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array(
-            'isClosure',
-            'getService',
-            'getMethod',
-        ));
+        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+            ->setMethods(array(
+                'isClosure',
+                'getService',
+                'getMethod',
+            ))
+            ->getMock();
 
         $constraint->expects($this->once())
             ->method('isClosure')
@@ -113,11 +118,13 @@ final class InlineValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateWithConstraintGetServiceIsNotString()
     {
-        $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array(
-            'isClosure',
-            'getService',
-            'getMethod',
-        ));
+        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+            ->setMethods(array(
+                'isClosure',
+                'getService',
+                'getMethod',
+            ))
+            ->getMock();
 
         $constraint->expects($this->once())
             ->method('isClosure')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is for tests only.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - `AbstractWidgetTestCase` uses `createMock` method
```

## Subject

The method `getMock` is deprecated.
