### PR TITLE
Improve error handling

### DIFF
--- a/Form/Type/ImmutableArrayType.php
+++ b/Form/Type/ImmutableArrayType.php
@@ -64,6 +64,21 @@ class ImmutableArrayType extends AbstractType
         $resolver->setDefaults(array(
             'keys' => array(),
         ));
+
+        // NEXT_MAJOR: remove the condition
+        if (!method_exists('Symfony\Component\OptionsResolver\OptionsResolver', 'setDefault')) {
+            return;
+        }
+
+        $resolver->setAllowedValues('keys', function ($value) {
+            foreach ($value as $subValue) {
+                if (!$subValue instanceof FormBuilderInterface && (!is_array($subValue) || count($subValue) !== 3)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -121,7 +121,7 @@ sonata_type_immutable_array
 The ``Immutable Array`` allows you to edit an array property by defining a type per key.
 
 The type has a ``keys`` parameter which contains the definition for each key.
-A definition is an array with 3 options:
+A definition is either a ``FormBuilder`` instance, or an array with 3 options:
 
 * key name,
 * type: a type name or a ``FormType`` instance,

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -157,8 +157,6 @@ Now, the property can be edited by setting a type for each type:
 
 .. code-block:: php
 
-        <?php
-
     <?php
     // src/AppBundle/Admin/PageAdmin.php
 

--- a/Tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/Tests/Form/Type/ImmutableArrayTypeTest.php
@@ -155,4 +155,39 @@ class ImmutableArrayTypeTest extends TypeTestCase
 
         $type->buildForm($builder, $options);
     }
+
+    public function testWithIncompleteOptions()
+    {
+        // NEXT_MAJOR: remove the condition
+        if (!method_exists('Symfony\Component\OptionsResolver\OptionsResolver', 'setDefault')) {
+            $this->markTestSkipped('closure validation is not available');
+        }
+
+        $optionsResolver = new OptionsResolver();
+
+        $type = new ImmutableArrayType();
+        $type->configureOptions($optionsResolver);
+
+        $this->setExpectedException(
+            'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException',
+            'The option "keys" with value array is invalid.'
+        );
+
+        $optionsResolver->resolve(array('keys' => array(array('test'))));
+    }
+
+    public function testFormBuilderIsAValidElement()
+    {
+        $optionsResolver = new OptionsResolver();
+
+        $type = new ImmutableArrayType();
+        $type->configureOptions($optionsResolver);
+
+        $this->assertArrayHasKey(
+            'keys',
+            $optionsResolver->resolve(array('keys' => array($this->getMockBuilder(
+                'Symfony\Component\Form\FormBuilderInterface'
+            )->getMock())))
+        );
+    }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Options for `ImmutableArrayType` are now validated, which should yield better results.
```

## Subject

Options for `ImmutableArrayType` are quite peculiar, and misusing this type can
lead to somewhat cryptic error messages, like for instance "Undefined offset:
2", from `app/cache/classes.php`, which does not help at all.
