### PR TITLE
Remove deprecated code

### DIFF
--- a/Form/EventListener/ResizeFormListener.php
+++ b/Form/EventListener/ResizeFormListener.php
@@ -31,7 +31,7 @@ class ResizeFormListener implements EventSubscriberInterface
     /**
      * @var bool
      */
-    private $resizeOnBind;
+    private $resizeOnSubmit;
 
     /**
      * @var array
@@ -46,22 +46,20 @@ class ResizeFormListener implements EventSubscriberInterface
     /**
      * @var \Closure
      */
-    private $preBindDataCallback;
+    private $preSubmitDataCallback;
 
     /**
-     * NEXT_MAJOR: rename $resizeOnBind to $resizeOnSubmit and $preBindDataCallback to $preSubmitDataCallback.
-     *
      * @param string        $type
      * @param array         $typeOptions
-     * @param bool          $resizeOnBind
-     * @param \Closure|null $preBindDataCallback
+     * @param bool          $resizeOnSubmit
+     * @param \Closure|null $preSubmitDataCallback
      */
-    public function __construct($type, array $typeOptions = array(), $resizeOnBind = false, $preBindDataCallback = null)
+    public function __construct($type, array $typeOptions = array(), $resizeOnSubmit = false, $preSubmitDataCallback = null)
     {
         $this->type = $type;
-        $this->resizeOnBind = $resizeOnBind;
+        $this->resizeOnSubmit = $resizeOnSubmit;
         $this->typeOptions = $typeOptions;
-        $this->preBindDataCallback = $preBindDataCallback;
+        $this->preSubmitDataCallback = $preSubmitDataCallback;
     }
 
     /**
@@ -141,7 +139,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     public function preSubmit(FormEvent $event)
     {
-        if (!$this->resizeOnBind) {
+        if (!$this->resizeOnSubmit) {
             return;
         }
 
@@ -168,8 +166,8 @@ class ResizeFormListener implements EventSubscriberInterface
                     'property_path' => '['.$name.']',
                 );
 
-                if ($this->preBindDataCallback) {
-                    $buildOptions['data'] = call_user_func($this->preBindDataCallback, $value);
+                if ($this->preSubmitDataCallback) {
+                    $buildOptions['data'] = call_user_func($this->preSubmitDataCallback, $value);
                 }
 
                 $options = array_merge($this->typeOptions, $buildOptions);
@@ -212,7 +210,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     public function onSubmit(FormEvent $event)
     {
-        if (!$this->resizeOnBind) {
+        if (!$this->resizeOnSubmit) {
             return;
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this renamed already deprecated variables.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #390 