### PR TITLE
Added missing datepicker options minViewMode

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -145,6 +145,7 @@ abstract class BasePickerType extends AbstractType
             'dp_collapse' => true,
             'dp_calendar_weeks' => false,
             'dp_view_mode' => 'days',
+            'dp_min_view_mode' => 'days',
         );
     }
 }

--- a/Resources/doc/reference/form_types.rst
+++ b/Resources/doc/reference/form_types.rst
@@ -443,6 +443,7 @@ Many of the `standard date picker options`_ are available by adding options with
                         'dp_collapse'           => true,
                         'dp_calendar_weeks'     => false,
                         'dp_view_mode'          => 'days',
+                        'dp_min_view_mode'      => 'days',
                 ))
 
                 // or sonata_type_date_picker if you don't need the time


### PR DESCRIPTION
I am targeting this branch, because I found one missing bootstrap-datepicker options [minViewMode](http://bootstrap-datepicker.readthedocs.io/en/latest/options.html#minviewmode).

## Changelog

```markdown
### Added
- Missing bootstrap datepicker options minViewMode (`dp_min_view_mode`)
```

