### PR TITLE
Fix translation has to be not null for twig 2.0

### DIFF
--- a/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
+++ b/Tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
@@ -21,7 +21,7 @@ class TemplateBoxTokenParserTest extends PHPUnit_Framework_TestCase
      * @dataProvider getTestsForRender
      *
      * @param bool            $enabled
-     * @param string          $source
+     * @param \Twig_Source    $source
      * @param TemplateBoxNode $expected
      *
      * @throws \Twig_Error_Syntax
@@ -32,6 +32,9 @@ class TemplateBoxTokenParserTest extends PHPUnit_Framework_TestCase
 
         $env = new \Twig_Environment(new \Twig_Loader_Array(array()), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
         $env->addTokenParser(new TemplateBoxTokenParser($enabled, $translator));
+        if (class_exists('\Twig_Source')) {
+            $source = new \Twig_Source($source, 'test');
+        }
         $stream = $env->tokenize($source);
         $parser = new \Twig_Parser($env);
 
@@ -40,10 +43,17 @@ class TemplateBoxTokenParserTest extends PHPUnit_Framework_TestCase
             $expected->getIterator()->getFlags(),
             $actual->getIterator()->getFlags()
         );
-        $this->assertSame(
-            $expected->getLine(),
-            $actual->getLine()
-        );
+        if (method_exists($expected, 'getLine')) {
+            $this->assertSame(
+                $expected->getLine(),
+                $actual->getLine()
+            );
+        } else {
+            $this->assertSame(
+                $expected->getTemplateLine(),
+                $actual->getTemplateLine()
+            );
+        }
         $this->assertSame(
             $expected->count(),
             $actual->count()

--- a/Twig/Node/TemplateBoxNode.php
+++ b/Twig/Node/TemplateBoxNode.php
@@ -38,7 +38,12 @@ class TemplateBoxNode extends \Twig_Node
         $this->enabled = $enabled;
         $this->translator = $translator;
 
-        parent::__construct(array('message' => $message, 'translationBundle' => $translationBundle), array(), $lineno, $tag);
+        $nodes = array('message' => $message);
+        if ($translationBundle) {
+            $nodes['translationBundle'] = $translationBundle;
+        }
+
+        parent::__construct($nodes, array(), $lineno, $tag);
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this fixes a bug with twig 2.0.

## Changelog

```markdown

### Fixed
- fixed Twig errors when using `sonata_template_box` without a translation domain

```

## Subject

Using `sonata_template_box` without a translation domain, results in passing a null value of `translationBundle` to Twig_Node constructor, which is no longer supported in Twig 2.0.

This PR resolves the issue by removing `translationBundle` if it is `null` from the passed parameters.

This is another solution for https://github.com/sonata-project/SonataMediaBundle/pull/1255
