### PR TITLE
Only add classes to compile on PHP < 7.0

### DIFF
--- a/DependencyInjection/SonataCoreExtension.php
+++ b/DependencyInjection/SonataCoreExtension.php
@@ -83,7 +83,9 @@ EOT
         $container->setParameter('sonata.core.form_type', $config['form_type']);
 
         $this->configureFormFactory($container, $config);
-        $this->configureClassesToCompile();
+        if (\PHP_VERSION_ID < 70000) {
+            $this->configureClassesToCompile();
+        }
 
         $this->deprecateSlugify($container);
 


### PR DESCRIPTION
I am targeting this branch, because this fix a deprecation warning and is BC.

## Changelog

```markdown
### Fixed
- deprecation notices related to `addClassesToCompile`
```

## Subject

Only call addClassesToCompile on PHP < 7.0 since it is deprecated and doesn't improve performances with PHP >= 7.0