### PR TITLE
Fixed choices_as_values deprecation warning in ColorSelectorType

### DIFF
--- a/Form/Type/ColorSelectorType.php
+++ b/Form/Type/ColorSelectorType.php
@@ -34,7 +34,8 @@ class ColorSelectorType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => Colors::getAll(),
+            'choices' => array_flip(Colors::getAll()),
+            'choices_as_values' => true,
             'translation_domain' => 'SonataCoreBundle',
             'preferred_choices' => array(
                 Colors::BLACK,

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -53,7 +53,8 @@ class ColorSelectorTypeTest extends TypeTestCase
         $type = new ColorSelectorType();
 
         $type->buildForm($formBuilder, array(
-            'choices' => Colors::getAll(),
+            'choices' => array_flip(Colors::getAll()),
+            'choices_as_values' => true,
             'translation_domain' => 'SonataCoreBundle',
             'preferred_choices' => array(
                 Colors::BLACK,
@@ -112,7 +113,7 @@ class ColorSelectorTypeTest extends TypeTestCase
         $options = $resolver->resolve();
 
         $expected = array(
-            'choices' => array(
+            'choices' => array_flip(array(
                 '#F0F8FF' => 'aliceblue',
                 '#FAEBD7' => 'antiquewhite',
                 '#00FFFF' => 'cyan',
@@ -252,7 +253,8 @@ class ColorSelectorTypeTest extends TypeTestCase
                 '#F5F5F5' => 'whitesmoke',
                 '#FFFF00' => 'yellow',
                 '#9ACD32' => 'yellowgreen',
-            ),
+            )),
+            'choices_as_values' => true,
             'translation_domain' => 'SonataCoreBundle',
             'preferred_choices' => array(
                 '#000000',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this fixes a deprecation notice regarding the use of `choices_as_values` in ColorSelectorType (depending on ChoiceType).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed deprecation notice in `ColorSelectorType` for Sf 3. support
```

## Subject

Fixed a Symfony 3 form choice type deprecation warning.

