### PR TITLE
Remove form compiler pass when mapping is disabled

### DIFF
--- a/SonataCoreBundle.php
+++ b/SonataCoreBundle.php
@@ -27,7 +27,10 @@ class SonataCoreBundle extends Bundle
     {
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
-        $container->addCompilerPass(new FormFactoryCompilerPass());
+
+        if ($container->hasDefinition('sonata.core.form.extension.dependency')) {
+            $container->addCompilerPass(new FormFactoryCompilerPass());
+        }
 
         $this->registerFormMapping();
     }

--- a/Tests/SonataCoreBundleTest.php
+++ b/Tests/SonataCoreBundleTest.php
@@ -26,8 +26,13 @@ final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
     public function testBuild()
     {
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(array('addCompilerPass'))
+            ->setMethods(array('addCompilerPass', 'hasDefinition'))
             ->getMock();
+
+        $containerBuilder->expects($this->once())
+            ->method('hasDefinition')
+            ->with('sonata.core.form.extension.dependency')
+            ->willReturn(true);
 
         $containerBuilder->expects($this->exactly(3))
             ->method('addCompilerPass')
@@ -49,6 +54,42 @@ final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
                     Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass", 
                     "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass" or 
                     "Sonata\AdminBundle\DependencyInjection\Compiler\FormFactoryCompilerPass", but got "%s".',
+                    get_class($pass)
+                ));
+            }));
+
+        $bundle = new SonataCoreBundle();
+        $bundle->build($containerBuilder);
+
+        $this->assertMappingTypeRegistered('form', 'Symfony\Component\Form\Extension\Core\Type\FormType');
+    }
+
+    public function testBuildWithFormMappingDisabled()
+    {
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('addCompilerPass', 'hasDefinition'))
+            ->getMock();
+
+        $containerBuilder->expects($this->once())
+            ->method('hasDefinition')
+            ->with('sonata.core.form.extension.dependency')
+            ->willReturn(false);
+
+        $containerBuilder->expects($this->exactly(2))
+            ->method('addCompilerPass')
+            ->will($this->returnCallback(function (CompilerPassInterface $pass) {
+                if ($pass instanceof StatusRendererCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof AdapterCompilerPass) {
+                    return;
+                }
+
+                $this->fail(sprintf(
+                    'Compiler pass is not one of the expected types. 
+                    Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass" or 
+                    "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass", but got "%s".',
                     get_class($pass)
                 ));
             }));


### PR DESCRIPTION
I am targeting this branch, because this is about about avoiding deprecation warnings.

## Changelog

```markdown
### Changed
- Removed add of `FormFactoryCompilerPass` when the option `form.mapping.enabled` is `false`
```

## Subject

I saw that there was an option for enabling form mapping (which defaults to true and was great for compatibility with Symfony <3)
As the `FormFactoryCompilerPass` was added  in #212 in the same time that this option, it seems that if we disable form mapping, the compiler pass is not necessary anymore.

Disabling the form mapping can be achieved with this config:
```yml
sonata_core:
    form:
        mapping:
            enabled: false
```

As the container parameter `sonata.core.form.mapping.type` is defined here ([DependencyInjection/SonataCoreExtension#L112](https://github.com/sonata-project/SonataCoreBundle/blob/3.x/DependencyInjection/SonataCoreExtension.php#L112)) based on the `form.mapping.enabled` configuration, I think we can use it to test if we need to add the `FormFactoryCompilerPass`

This will also avoid deprecation warnings for Symfony 4.0, but only when the form mapping is disabled. (The main purpose of this PR)

_I'm not sure if this is the right solution, but this is a proposal._