### PR TITLE
Fixed passing empty translation domain to sonata_template_box

### DIFF
--- a/Twig/Node/TemplateBoxNode.php
+++ b/Twig/Node/TemplateBoxNode.php
@@ -39,6 +39,7 @@ class TemplateBoxNode extends \Twig_Node
         $this->translator = $translator;
 
         $nodes = array('message' => $message);
+
         if ($translationBundle) {
             $nodes['translationBundle'] = $translationBundle;
         }
@@ -62,7 +63,11 @@ class TemplateBoxNode extends \Twig_Node
 
         $value = $this->getNode('message')->getAttribute('value');
 
-        $translationBundle = $this->getNode('translationBundle');
+        $translationBundle = null;
+
+        if ($this->hasNode('translationBundle')) {
+            $translationBundle = $this->getNode('translationBundle');
+        }
 
         if ($translationBundle) {
             $translationBundle = $translationBundle->getAttribute('value');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed passing empty translation domain to `sonata_template_box`
```

## Subject

Without this fix, you will get a `LogicException` if you try to access the non-existing `translationBundle`.
