### PR TITLE
[WIP] Clean managers

### DIFF
--- a/Model/ManagerInterface.php
+++ b/Model/ManagerInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\DBAL\Connection;
-
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
@@ -24,44 +22,6 @@ interface ManagerInterface
      * @return string
      */
     public function getClass();
-
-    /**
-     * Find all entities in the repository.
-     *
-     * @return array
-     */
-    public function findAll();
-
-    /**
-     * Find entities by a set of criteria.
-     *
-     * @param array      $criteria
-     * @param array|null $orderBy
-     * @param int|null   $limit
-     * @param int|null   $offset
-     *
-     * @return array
-     */
-    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null);
-
-    /**
-     * Find a single entity by a set of criteria.
-     *
-     * @param array      $criteria
-     * @param array|null $orderBy
-     *
-     * @return object|null
-     */
-    public function findOneBy(array $criteria, array $orderBy = null);
-
-    /**
-     * Finds an entity by its primary key / identifier.
-     *
-     * @param mixed $id The identifier
-     *
-     * @return object
-     */
-    public function find($id);
 
     /**
      * Create an empty Entity instance.
@@ -85,18 +45,4 @@ interface ManagerInterface
      * @param bool   $andFlush Flush the EntityManager after deleting the object?
      */
     public function delete($entity, $andFlush = true);
-
-    /**
-     * Get the related table name.
-     *
-     * @return string
-     */
-    public function getTableName();
-
-    /**
-     * Get the DB driver connection.
-     *
-     * @return Connection
-     */
-    public function getConnection();
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Clean ManagerInterface by removing `getTableName`, `getConnection` and all `find*` methods
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update implementations
- [ ] Add an upgrade note

## Subject

The managers are very technical and propagate some repository methods. Instead the concrete bundle manager should contain domain specific methods.
