### PR TITLE
Added missing datepicker options pickDate.

### DIFF
--- a/Form/Type/BasePickerType.php
+++ b/Form/Type/BasePickerType.php
@@ -125,6 +125,7 @@ abstract class BasePickerType extends AbstractType
             'widget' => 'single_text',
             'datepicker_use_button' => true,
             'dp_pick_time' => true,
+            'dp_pick_date' => true,
             'dp_use_current' => true,
             'dp_min_date' => '1/1/1900',
             'dp_max_date' => null,

--- a/Resources/views/Form/datepicker.html.twig
+++ b/Resources/views/Form/datepicker.html.twig
@@ -39,12 +39,14 @@ file that was distributed with this source code.
 
 {% block sonata_type_datetime_picker_widget_html %}
     {% if datepicker_use_button %}
-        <div class='input-group date' id='dtp_{{ id }}'>
+        <div class='input-group date {% if not dp_options['pickDate'] %}timepicker{% endif %}' id='dtp_{{ id }}'>
     {% endif %}
     {% set attr = attr|merge({'data-date-format': moment_format}) %}
     {{ block('datetime_widget') }}
     {% if datepicker_use_button %}
-          <span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+            <span class="input-group-addon">
+                <span class="fa {% if dp_options['pickDate'] %}fa-calendar{% else %}fa-clock{% endif %}"></span>
+            </span>
         </div>
     {% endif %}
 {% endblock sonata_type_datetime_picker_widget_html %}


### PR DESCRIPTION
Added the ability for datetime to display only time. The default icon now changes depending on the pickDate option

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added dp_option "dp_pick_date" in BasePickerType

### Changed
- Changed template datepicker.html.twig to display the time icon
