### PR TITLE
Revert "Remove form compiler pass when mapping is disabled (#412)"

### DIFF
--- a/SonataCoreBundle.php
+++ b/SonataCoreBundle.php
@@ -27,10 +27,7 @@ class SonataCoreBundle extends Bundle
     {
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
-
-        if ($container->hasDefinition('sonata.core.form.extension.dependency')) {
-            $container->addCompilerPass(new FormFactoryCompilerPass());
-        }
+        $container->addCompilerPass(new FormFactoryCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/Tests/SonataCoreBundleTest.php
+++ b/Tests/SonataCoreBundleTest.php
@@ -26,13 +26,8 @@ final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
     public function testBuild()
     {
         $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(array('addCompilerPass', 'hasDefinition'))
+            ->setMethods(array('addCompilerPass'))
             ->getMock();
-
-        $containerBuilder->expects($this->once())
-            ->method('hasDefinition')
-            ->with('sonata.core.form.extension.dependency')
-            ->willReturn(true);
 
         $containerBuilder->expects($this->exactly(3))
             ->method('addCompilerPass')
@@ -54,42 +49,6 @@ final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
                     Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass", 
                     "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass" or 
                     "Sonata\AdminBundle\DependencyInjection\Compiler\FormFactoryCompilerPass", but got "%s".',
-                    get_class($pass)
-                ));
-            }));
-
-        $bundle = new SonataCoreBundle();
-        $bundle->build($containerBuilder);
-
-        $this->assertMappingTypeRegistered('form', 'Symfony\Component\Form\Extension\Core\Type\FormType');
-    }
-
-    public function testBuildWithFormMappingDisabled()
-    {
-        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(array('addCompilerPass', 'hasDefinition'))
-            ->getMock();
-
-        $containerBuilder->expects($this->once())
-            ->method('hasDefinition')
-            ->with('sonata.core.form.extension.dependency')
-            ->willReturn(false);
-
-        $containerBuilder->expects($this->exactly(2))
-            ->method('addCompilerPass')
-            ->will($this->returnCallback(function (CompilerPassInterface $pass) {
-                if ($pass instanceof StatusRendererCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AdapterCompilerPass) {
-                    return;
-                }
-
-                $this->fail(sprintf(
-                    'Compiler pass is not one of the expected types. 
-                    Expects "Sonata\AdminBundle\DependencyInjection\Compiler\StatusRendererCompilerPass" or 
-                    "Sonata\AdminBundle\DependencyInjection\Compiler\AdapterCompilerPass", but got "%s".',
                     get_class($pass)
                 ));
             }));


### PR DESCRIPTION
This reverts commit 79a54ec9c8c29660bea17735e7c89e4a2e79b2c2.

## Changelog

```markdown
### Fixed
- Datagrid build form issue caused by a regression on release 3.5.0
```

@deguif I revert your PR because this cause a huge regression.

In any list, while building the datagrid:

```
The extended type specified for the service "form.extension.form" does not match the actual extended type. Expected "Symfony\Component\Form\Extension\Core\Type\FormType", given "".
```

My sonata config FYI:

```yaml
# Sonata Configuration
sonata_block:
    default_contexts: [cms]
    blocks:
        sonata.admin.block.admin_list:
            contexts:   [admin]
        sonata.admin.block.search_result:
            contexts:   [admin]
        block.admin.quick_info:
            contexts:   [admin]
        block.admin.support_info:
            contexts:   [admin]
        block.admin.incident_info:
            contexts:   [admin]
        block.admin.active_users:
            contexts:   [admin]

sonata_admin:
    options:
        lock_protection: true
        form_type: horizontal
    security:
        handler: sonata.admin.security.handler.role
    title: Administration
    title_logo: favicon.png
    persist_filters: true
    show_mosaic_button: false
    dashboard:
        blocks:
            -
                position: top
                class: col-md-12
                type: block.admin.quick_info
            -
                position: top
                class: col-lg-12
                type: block.admin.active_users
            -
                position: top
                class: col-md-12
                type: block.admin.support_info
            -
                position: top
                class: col-md-12
                type: block.admin.incident_info
    # Note: Some templates have to be overridden on app/Resources/SonataAdminBundle/views
    templates:
        layout:       admin/standard_layout.html.twig
        user_block:   admin/Core/user_block.html.twig
        list:         admin/CRUD/list.html.twig
        edit:         admin/CRUD/edit.html.twig
        search_result_block: admin/Block/block_search_result.html.twig

sonata_doctrine_orm_admin:
    audit:
        force: false
    templates:
        types:
            list:
                user:       admin/CRUD/list_user.html.twig
                users:      admin/CRUD/list_users.html.twig
                enum:       admin/CRUD/list_enum.html.twig
            show:
                user:       admin/CRUD/show_user.html.twig
                ticket:     admin/CRUD/show_ticket.html.twig
                enum:       admin/CRUD/show_enum.html.twig
                markdown:   admin/CRUD/show_markdown.html.twig
```

Feel free to make a new working one later.

@sonata-project/contributors Please take care to manual testing if this kind of change is submitted again.