### PR TITLE
Remove translation for sonata_template_box

### DIFF
--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -15,7 +15,6 @@
         <service id="sonata.core.twig.template_extension" class="Sonata\CoreBundle\Twig\Extension\TemplateExtension">
             <tag name="twig.extension"/>
             <argument>%kernel.debug%</argument>
-            <argument type="service" id="translator"/>
             <argument type="service" id="sonata.core.model.adapter.chain"/>
         </service>
     </services>

--- a/Resources/translations/SonataCoreBundle.ar.xliff
+++ b/Resources/translations/SonataCoreBundle.ar.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>لا يحتوي</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>يساوي</target>

--- a/Resources/translations/SonataCoreBundle.bg.xliff
+++ b/Resources/translations/SonataCoreBundle.bg.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>не</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>съвпада със</target>

--- a/Resources/translations/SonataCoreBundle.ca.xliff
+++ b/Resources/translations/SonataCoreBundle.ca.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>Aquest arxiu és pot trobar a</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>és igual a</target>

--- a/Resources/translations/SonataCoreBundle.cs.xliff
+++ b/Resources/translations/SonataCoreBundle.cs.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>ne</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>rovná se</target>

--- a/Resources/translations/SonataCoreBundle.de.xliff
+++ b/Resources/translations/SonataCoreBundle.de.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nein</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>ist gleich</target>

--- a/Resources/translations/SonataCoreBundle.en.xliff
+++ b/Resources/translations/SonataCoreBundle.en.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>This file can be found in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>is equal to</target>

--- a/Resources/translations/SonataCoreBundle.es.xliff
+++ b/Resources/translations/SonataCoreBundle.es.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>Este archivo se puede encontrar en</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>igual a</target>

--- a/Resources/translations/SonataCoreBundle.eu.xliff
+++ b/Resources/translations/SonataCoreBundle.eu.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>Ez</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>berdina da</target>

--- a/Resources/translations/SonataCoreBundle.fa.xliff
+++ b/Resources/translations/SonataCoreBundle.fa.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>خیر</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>برابر است با</target>

--- a/Resources/translations/SonataCoreBundle.fi.xliff
+++ b/Resources/translations/SonataCoreBundle.fi.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>ei</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>on yhtä kuin</target>

--- a/Resources/translations/SonataCoreBundle.fr.xliff
+++ b/Resources/translations/SonataCoreBundle.fr.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>non</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>Ce fichier est localisé à l'emplacement</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>Est égal à</target>

--- a/Resources/translations/SonataCoreBundle.hr.xliff
+++ b/Resources/translations/SonataCoreBundle.hr.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>ne</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>jednak</target>

--- a/Resources/translations/SonataCoreBundle.hu.xliff
+++ b/Resources/translations/SonataCoreBundle.hu.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nem</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>egyenlő</target>

--- a/Resources/translations/SonataCoreBundle.it.xliff
+++ b/Resources/translations/SonataCoreBundle.it.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>no</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>è uguale a</target>

--- a/Resources/translations/SonataCoreBundle.ja.xliff
+++ b/Resources/translations/SonataCoreBundle.ja.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>いいえ</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>This file can be found in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>等しい</target>

--- a/Resources/translations/SonataCoreBundle.lb.xliff
+++ b/Resources/translations/SonataCoreBundle.lb.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nee</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>ass gläich</target>

--- a/Resources/translations/SonataCoreBundle.lt.xliff
+++ b/Resources/translations/SonataCoreBundle.lt.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>ne</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>yra lygus</target>

--- a/Resources/translations/SonataCoreBundle.nl.xliff
+++ b/Resources/translations/SonataCoreBundle.nl.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nee</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>Dit bestand is te vinden in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>is gelijk aan</target>

--- a/Resources/translations/SonataCoreBundle.pl.xliff
+++ b/Resources/translations/SonataCoreBundle.pl.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nie</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>jest równe</target>

--- a/Resources/translations/SonataCoreBundle.pt.xliff
+++ b/Resources/translations/SonataCoreBundle.pt.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>não</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>é igual a</target>

--- a/Resources/translations/SonataCoreBundle.pt_BR.xliff
+++ b/Resources/translations/SonataCoreBundle.pt_BR.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>não</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>é igual a</target>

--- a/Resources/translations/SonataCoreBundle.ro.xliff
+++ b/Resources/translations/SonataCoreBundle.ro.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nu</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>este egal cu</target>

--- a/Resources/translations/SonataCoreBundle.ru.xliff
+++ b/Resources/translations/SonataCoreBundle.ru.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>нет</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>равен</target>

--- a/Resources/translations/SonataCoreBundle.sk.xliff
+++ b/Resources/translations/SonataCoreBundle.sk.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>nie</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>Tento súbor možno nájsť v</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>sa rovná</target>

--- a/Resources/translations/SonataCoreBundle.sl.xliff
+++ b/Resources/translations/SonataCoreBundle.sl.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>ne</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>To datoteko je možno najti v</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>je točno enako</target>

--- a/Resources/translations/SonataCoreBundle.uk.xliff
+++ b/Resources/translations/SonataCoreBundle.uk.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>немає</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>дорівнює</target>

--- a/Resources/translations/SonataCoreBundle.zh_CN.xliff
+++ b/Resources/translations/SonataCoreBundle.zh_CN.xliff
@@ -14,10 +14,6 @@
                 <source>label_type_no</source>
                 <target>否</target>
             </trans-unit>
-            <trans-unit id="sonata_core_template_box_file_found_in">
-                <source>sonata_core_template_box_file_found_in</source>
-                <target>sonata_core_template_box_file_found_in</target>
-            </trans-unit>
             <trans-unit id="label_type_equals">
                 <source>label_type_equals</source>
                 <target>label_type_equals</target>

--- a/Tests/Twig/Extension/TemplateExtensionTest.php
+++ b/Tests/Twig/Extension/TemplateExtensionTest.php
@@ -18,12 +18,10 @@ class TemplateExtensionTest extends PHPUnit_Framework_TestCase
 {
     public function testSafeUrl()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-
         $adapter = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
         $adapter->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue('safe-parameter'));
 
-        $extension = new TemplateExtension(true, $translator, $adapter);
+        $extension = new TemplateExtension(true, $adapter);
 
         $this->assertSame('safe-parameter', $extension->getUrlsafeIdentifier(new \stdClass()));
     }

--- a/Tests/Twig/Node/TemplateBoxNodeTest.php
+++ b/Tests/Twig/Node/TemplateBoxNodeTest.php
@@ -12,21 +12,14 @@
 namespace Sonata\CoreBundle\Tests\Twig\TokenParser;
 
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
-use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\MessageSelector;
-use Symfony\Component\Translation\Translator;
 
 class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
 {
     public function testConstructor()
     {
-        $translator = $this->getTranslator('en');
-
         $body = new TemplateBoxNode(
             new \Twig_Node_Expression_Constant('This is the default message', 1),
-            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
             true,
-            $translator,
             1,
             'sonata_template_box'
         );
@@ -55,24 +48,16 @@ class TemplateBoxNodeTest extends \Twig_Test_NodeTestCase
      */
     public function getTests()
     {
-        $translator = $this->getTranslator('en');
-
         $nodeEn = new TemplateBoxNode(
             new \Twig_Node_Expression_Constant('This is the default message', 1),
-            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
             true,
-            $translator,
             1,
             'sonata_template_box'
         );
 
-        $translator = $this->getTranslator('fr');
-
         $nodeFr = new TemplateBoxNode(
             new \Twig_Node_Expression_Constant('Ceci est le message par défaut', 1),
-            new \Twig_Node_Expression_Constant('SonataCoreBundle', 1),
             true,
-            $translator,
             1,
             'sonata_template_box'
         );
@@ -90,30 +75,10 @@ EOF
 // line 1
 echo "<div class='alert alert-default alert-info'>
     <strong>Ceci est le message par défaut</strong>
-    <div>Ce fichier peut être trouvé à l'emplacement <code>{$this->getTemplateName()}</code>.</div>
+    <div>This file can be found in <code>{$this->getTemplateName()}</code>.</div>
 </div>";
 EOF
             ],
         ];
-    }
-
-    /**
-     * Returns a Translator instance.
-     *
-     * @param string $locale
-     *
-     * @return Translator
-     */
-    public function getTranslator($locale)
-    {
-        $translator = new Translator($locale, new MessageSelector());
-        $translator->addLoader('array', new ArrayLoader());
-
-        $translator->addResource('array', ['sonata_template_box_media_gallery_block' => 'This is the default message'], 'en', 'SonataCoreBundle');
-        $translator->addResource('array', ['sonata_template_box_media_gallery_block' => 'Ceci est le message par défaut'], 'fr', 'SonataCoreBundle');
-        $translator->addResource('array', ['sonata_core_template_box_file_found_in' => 'This file can be found in'], 'en', 'SonataCoreBundle');
-        $translator->addResource('array', ['sonata_core_template_box_file_found_in' => "Ce fichier peut être trouvé à l'emplacement"], 'fr', 'SonataCoreBundle');
-
-        return $translator;
     }
 }

--- a/Twig/Extension/TemplateExtension.php
+++ b/Twig/Extension/TemplateExtension.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Twig\Extension;
 
 use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateExtension extends \Twig_Extension
 {
@@ -28,19 +27,12 @@ class TemplateExtension extends \Twig_Extension
     protected $modelAdapter;
 
     /**
-     * @var TranslatorInterface
+     * @param bool             $debug        Is Symfony debug enabled?
+     * @param AdapterInterface $modelAdapter A Sonata model adapter
      */
-    protected $translator;
-
-    /**
-     * @param bool                $debug        Is Symfony debug enabled?
-     * @param TranslatorInterface $translator   Symfony Translator service
-     * @param AdapterInterface    $modelAdapter A Sonata model adapter
-     */
-    public function __construct($debug, TranslatorInterface $translator, AdapterInterface $modelAdapter)
+    public function __construct($debug, AdapterInterface $modelAdapter)
     {
         $this->debug = $debug;
-        $this->translator = $translator;
         $this->modelAdapter = $modelAdapter;
     }
 
@@ -60,7 +52,7 @@ class TemplateExtension extends \Twig_Extension
     public function getTokenParsers()
     {
         return [
-            new TemplateBoxTokenParser($this->debug, $this->translator),
+            new TemplateBoxTokenParser($this->debug),
         ];
     }
 

--- a/Twig/Node/TemplateBoxNode.php
+++ b/Twig/Node/TemplateBoxNode.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
-use Symfony\Component\Translation\TranslatorInterface;
-
 class TemplateBoxNode extends \Twig_Node
 {
     /**
@@ -21,30 +19,16 @@ class TemplateBoxNode extends \Twig_Node
     protected $enabled;
 
     /**
-     * @var TranslatorInterface
+     * @param \Twig_Node_Expression $message Node message to display
+     * @param int                   $enabled Is Symfony debug enabled?
+     * @param null|string           $lineno  Symfony template line number
+     * @param null                  $tag     Symfony tag name
      */
-    protected $translator;
-
-    /**
-     * @param \Twig_Node_Expression $message           Node message to display
-     * @param \Twig_Node_Expression $translationBundle Node translation bundle to use for display
-     * @param int                   $enabled           Is Symfony debug enabled?
-     * @param TranslatorInterface   $translator        Symfony Translator service
-     * @param null|string           $lineno            Symfony template line number
-     * @param null                  $tag               Symfony tag name
-     */
-    public function __construct(\Twig_Node_Expression $message, \Twig_Node_Expression $translationBundle = null, $enabled, TranslatorInterface $translator, $lineno, $tag = null)
+    public function __construct(\Twig_Node_Expression $message, $enabled, $lineno, $tag = null)
     {
         $this->enabled = $enabled;
-        $this->translator = $translator;
 
-        $nodes = ['message' => $message];
-
-        if ($translationBundle) {
-            $nodes['translationBundle'] = $translationBundle;
-        }
-
-        parent::__construct($nodes, [], $lineno, $tag);
+        parent::__construct(['message' => $message], [], $lineno, $tag);
     }
 
     /**
@@ -63,20 +47,10 @@ class TemplateBoxNode extends \Twig_Node
 
         $value = $this->getNode('message')->getAttribute('value');
 
-        $translationBundle = null;
-
-        if ($this->hasNode('translationBundle')) {
-            $translationBundle = $this->getNode('translationBundle');
-        }
-
-        if ($translationBundle) {
-            $translationBundle = $translationBundle->getAttribute('value');
-        }
-
         $message = <<<CODE
 "<div class='alert alert-default alert-info'>
-    <strong>{$this->translator->trans($value, [], $translationBundle)}</strong>
-    <div>{$this->translator->trans('sonata_core_template_box_file_found_in', [], 'SonataCoreBundle')} <code>{\$this->getTemplateName()}</code>.</div>
+    <strong>{$value}</strong>
+    <div>This file can be found in <code>{\$this->getTemplateName()}</code>.</div>
 </div>"
 CODE;
 

--- a/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -12,7 +12,6 @@
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateBoxTokenParser extends \Twig_TokenParser
 {
@@ -22,18 +21,11 @@ class TemplateBoxTokenParser extends \Twig_TokenParser
     protected $enabled;
 
     /**
-     * @var TranslatorInterface
+     * @param bool $enabled Is Symfony debug enabled?
      */
-    protected $translator;
-
-    /**
-     * @param bool                $enabled    Is Symfony debug enabled?
-     * @param TranslatorInterface $translator Symfony Translator service
-     */
-    public function __construct($enabled, TranslatorInterface $translator)
+    public function __construct($enabled)
     {
         $this->enabled = $enabled;
-        $this->translator = $translator;
     }
 
     /**
@@ -55,7 +47,7 @@ class TemplateBoxTokenParser extends \Twig_TokenParser
 
         $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new TemplateBoxNode($message, $translationBundle, $this->enabled, $this->translator, $token->getLine(), $this->getTag());
+        return new TemplateBoxNode($message, $translationBundle, $this->enabled, $token->getLine(), $this->getTag());
     }
 
     /**

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -11,3 +11,7 @@ Install `cocur/slugify` and enable `CocurSlugifyBundle` https://github.com/cocur
 ### Deprecations in forms
 
 The translator in ``DateRangeType``, ``DateTimeRangeType``, ``EqualType`` has been deprecated. 
+
+### Removed translation for `sonata_template_box`
+
+The ability of translating the text of `sonata_template_box` twig nodes was removed.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed translation for `sonata_template_box`
```

## Subject

There is no good reason to translate the text which is only visibly to developers.
