### PR TITLE
register sonata_type_color in form mapping

### DIFF
--- a/SonataCoreBundle.php
+++ b/SonataCoreBundle.php
@@ -94,6 +94,7 @@ class SonataCoreBundle extends Bundle
             'sonata_type_date_range_picker' => 'Sonata\CoreBundle\Form\Type\DateRangePickerType',
             'sonata_type_datetime_range_picker' => 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType',
             'sonata_type_equal' => 'Sonata\CoreBundle\Form\Type\EqualType',
+            'sonata_type_color' => 'Sonata\CoreBundle\Form\Type\ColorType',
             'sonata_type_color_selector' => 'Sonata\CoreBundle\Form\Type\ColorSelectorType',
         ));
 

--- a/Tests/SonataCoreBundleTest.php
+++ b/Tests/SonataCoreBundleTest.php
@@ -126,6 +126,7 @@ final class SonataCoreBundleTest extends PHPUnit_Framework_TestCase
             array('sonata_type_date_range_picker', 'Sonata\CoreBundle\Form\Type\DateRangePickerType'),
             array('sonata_type_datetime_range_picker', 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType'),
             array('sonata_type_equal', 'Sonata\CoreBundle\Form\Type\EqualType'),
+            array('sonata_type_color', 'Sonata\CoreBundle\Form\Type\ColorType'),
             array('sonata_type_color_selector', 'Sonata\CoreBundle\Form\Type\ColorSelectorType'),
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #438

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- missing form mapping for `sonata_type_color`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

