### PR TITLE
Updating cocur/slugify to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "cocur/slugify": "^1.4 || ^2.0",
+        "cocur/slugify": "^1.4 || ^2.0 || ^3.0",
         "sonata-project/datagrid-bundle": "^2.0",
         "symfony/config": "^2.8 || ^3.2",
         "symfony/form": "^2.8 || ^3.2",


### PR DESCRIPTION
This enables support for slugs using rules for languages such as Brazilian Portuguese, Hungarian and Persian.

I am targeting this branch, because this change just enable new language rules and it's backwards safe.

Closes #447 

## Changelog

```markdown

### Added
- Support of cocur/slugify 3.x
```

## Subject
This enables support for slugs using rules for languages such as Brazilian Portuguese, Hungarian and Persian.
