### PR TITLE
remove deprecated FormPass and ColorSelectorType

### DIFF
--- a/DependencyInjection/Compiler/FormFactoryCompilerPass.php
+++ b/DependencyInjection/Compiler/FormFactoryCompilerPass.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\CoreBundle\DependencyInjection\Compiler;
 
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\DependencyInjection\FormPass;
 
 class FormFactoryCompilerPass extends FormPass
 {

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -13,7 +13,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Color\Colors;
 use Sonata\CoreBundle\Form\FormHelper;
-use Sonata\CoreBundle\Form\Type\ColorSelectorType;
+use Sonata\CoreBundle\Form\Type\ColorType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ColorSelectorTypeTest extends TypeTestCase
@@ -49,7 +49,7 @@ class ColorSelectorTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new ColorSelectorType();
+        $type = new ColorType();
 
         $type->buildForm($formBuilder, [
             'choices' => array_flip(Colors::getAll()),
@@ -72,7 +72,7 @@ class ColorSelectorTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new ColorSelectorType();
+        $form = new ColorType();
 
         // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
@@ -97,7 +97,7 @@ class ColorSelectorTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new ColorSelectorType();
+        $type = new ColorType();
 
         $this->assertSame('sonata_type_color_selector', $type->getName());
         $this->assertSame(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
