### PR TITLE
Register commands as services

### DIFF
--- a/src/DependencyInjection/SonataCoreExtension.php
+++ b/src/DependencyInjection/SonataCoreExtension.php
@@ -78,6 +78,7 @@ EOT
         $loader->load('twig.xml');
         $loader->load('model_adapter.xml');
         $loader->load('core.xml');
+        $loader->load('commands.xml');
 
         $this->registerFlashTypes($container, $config);
         $container->setParameter('sonata.core.form_type', $config['form_type']);

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\CoreBundle\Command\SonataDumpDoctrineMetaCommand" class="Sonata\CoreBundle\Command\SonataDumpDoctrineMetaCommand">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\CoreBundle\Command\SonataListFormMappingCommand" class="Sonata\CoreBundle\Command\SonataListFormMappingCommand">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because deprecation notices are thrown after update to Symfony 3.4.
Closes https://github.com/sonata-project/SonataAdminBundle/issues/4703
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Register commands as services to prevent deprecation notices on Symfony 3.4
```


<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->


## Subject
After updating Symfony version to 3.4 the following deprecation notices are thrown:
> Auto-registration of the command "Sonata\CoreBundle\Command\SonataDumpDoctrineMetaCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead.
