### PR TITLE
Add legacy class to fix old Form compilation pass

### DIFF
--- a/DependencyInjection/Compiler/LegacyFormFactoryCompilerPass.php
+++ b/DependencyInjection/Compiler/LegacyFormFactoryCompilerPass.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\CoreBundle\DependencyInjection\Compiler;
 
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Form\DependencyInjection\FormPass;
 
-class FormFactoryCompilerPass extends FormPass
+class LegacyFormFactoryCompilerPass extends FormPass
 {
     /**
      * {@inheritdoc}

--- a/SonataCoreBundle.php
+++ b/SonataCoreBundle.php
@@ -11,11 +11,12 @@
 
 namespace Sonata\CoreBundle;
 
+use Sonata\CoreBundle\DependencyInjection\Compiler;
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
-use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataCoreBundle extends Bundle
@@ -27,7 +28,11 @@ class SonataCoreBundle extends Bundle
     {
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
-        $container->addCompilerPass(new FormFactoryCompilerPass());
+        if (class_exists(FormPass::class)) {
+            $container->addCompilerPass(new Compiler\FormFactoryCompilerPass());
+        } else {
+            $container->addCompilerPass(new Compiler\LegacyFormFactoryCompilerPass());
+        }
 
         $this->registerFormMapping();
     }


### PR DESCRIPTION
I am targeting this branch, because this does not break BC.

Closes sonata-project/SonataAdminBundle#4700
## Changelog
```
### Fixed
DependencyInjection/Compiler/FormFactoryCompilerPass.php
DependencyInjection/Compiler/LegacyFormFactoryCompilerPass.php
SonataCoreBundle.php
```
## Subject
Introduced legacy class to mantain compatibility with old sf versions and to provide a solution against deprecation warnings raised because old `FormFactoryCompilerPass` extends deprecated `FormPass`.

After this change if the new `FormPass` class is available, lt will be correctly extended by  `FormFactoryCompilerPass` while  `LegacyFormFactoryCompilerPass` still will mantain BC.