### PR TITLE
Sf 3.4 compat

### DIFF
--- a/Test/AbstractWidgetTestCase.php
+++ b/Test/AbstractWidgetTestCase.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslat
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Base class for tests checking rendering of form widgets.
@@ -50,21 +51,13 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         }
         parent::setUp();
 
-        // NEXT_MAJOR: Remove BC hack when dropping symfony 2.4 support
-        $csrfProviderClasses = array_filter([
-            // symfony <=2.4
-            'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface',
-            // symfony >=2.4
-            'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface',
-        ], 'interface_exists');
-
         // TODO: remove the condition when dropping symfony/twig-bundle < 3.2
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
             $this->extension = new FormExtension();
             $environment = $this->getEnvironment();
             $this->renderer = new TwigRenderer(
                 $this->getRenderingEngine($environment),
-                $this->createMock(current($csrfProviderClasses))
+                $this->createMock(CsrfTokenManagerInterface::class)
             );
             $runtimeLoader = $this
                 ->getMockBuilder('Twig_RuntimeLoaderInterface')
@@ -79,7 +72,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         } else {
             $this->renderer = new TwigRenderer(
                 $this->getRenderingEngine(),
-                $this->createMock(current($csrfProviderClasses))
+                $this->createMock(CsrfTokenManagerInterface::class)
             );
             $this->extension = new FormExtension($this->renderer);
             $environment = $this->getEnvironment();

--- a/Tests/Form/Type/ColorSelectorTypeTest.php
+++ b/Tests/Form/Type/ColorSelectorTypeTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ColorSelectorTypeTest extends TypeTestCase
 {
+    /**
+     * @group legacy
+     */
     public function testBuildForm()
     {
         // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/twig-bridge": "^2.8 || ^3.2",
         "symfony/validator": "^2.8 || ^3.2",
         "twig/extensions": "^1.0",
-        "twig/twig": "^1.23 || ^2.0"
+        "twig/twig": "^1.30 || ^2.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
I am targeting this branch, because this does not break BC.
## Changelog

```markdown
### Fixed
- reusable test case `Sonata\CoreBundle\Test\AbstractWidgetTestCase` is now compatible with Symfony 3.4
```


## Subject

This fixes the 3.4 build.
