### PR TITLE
Deprecate the form mapping feature

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,18 @@
 UPGRADE 3.x
 ===========
 
+Using the form mapping feature is now deprecated. You should use FQCNs
+everywhere form names are used, and disable this feature with the following
+piece of configuration:
+
+```yaml
+# config.yml
+sonata_core:
+    form:
+        mapping:
+            enabled: false
+```
+
 UPGRADE FROM 3.4 to 3.5
 =======================
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -13,9 +13,11 @@ client only sent partial data to update an entity.
 
     <?php
 
+    use Sonata\ClassificationBundle\Form\Type\ApiCategoryType;
+
     $category = $id ? $this->getCategory($id) : null;
 
-    $form = $this->formFactory->createNamed(null, 'sonata_classification_api_form_category', $category, array(
+    $form = $this->formFactory->createNamed(null, ApiCategoryType::class, $category, array(
         'csrf_protection' => false
     ));
 

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -37,7 +37,10 @@ Configuration
 
         # app/config/config.yml
 
-        sonata_core: ~
+        sonata_core:
+            form:
+                mapping:
+                    enabled: false
 
 When using bootstrap, some widgets need to be wrapped in a special ``div`` element
 depending on whether you are using the standard style for your forms or the

--- a/src/Command/SonataListFormMappingCommand.php
+++ b/src/Command/SonataListFormMappingCommand.php
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
+/**
+ * @deprecated since 3.x, to be removed in 4.0, the form mapping feature should be disabled.
+ */
 class SonataListFormMappingCommand extends ContainerAwareCommand
 {
     /**

--- a/src/DependencyInjection/Compiler/FormFactoryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormFactoryCompilerPass.php
@@ -14,6 +14,9 @@ namespace Sonata\CoreBundle\DependencyInjection\Compiler;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @deprecated since 3.x, to be removed in 4.0, the form mapping feature should be disabled.
+ */
 class FormFactoryCompilerPass extends FormPass
 {
     /**

--- a/src/DependencyInjection/SonataCoreExtension.php
+++ b/src/DependencyInjection/SonataCoreExtension.php
@@ -117,6 +117,11 @@ EOT
             return;
         }
 
+        @trigger_error(
+            'Relying on the form mapping feature is deprecated since 3.x and will be removed in 4.0. Please set the "sonata_core.form.mapping.enabled" configuration node to false to avoid this message.',
+            E_USER_DEPRECATED
+        );
+
         $container->setParameter('sonata.core.form.mapping.type', $config['form']['mapping']['type']);
         $container->setParameter('sonata.core.form.mapping.extension', $config['form']['mapping']['extension']);
 

--- a/src/Form/Extension/DependencyInjectionExtension.php
+++ b/src/Form/Extension/DependencyInjectionExtension.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 /**
  * This proxy class help to keep BC code with < SF2.8 form behavior by restoring
  * the type as a code and not as a class.
+ *
+ * @deprecated since 3.x, to be removed in 4.0, the form mapping feature should be disabled.
  */
 class DependencyInjectionExtension implements FormExtensionInterface
 {

--- a/tests/DependencyInjection/SonataCoreExtensionTest.php
+++ b/tests/DependencyInjection/SonataCoreExtensionTest.php
@@ -18,7 +18,7 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
 {
     public function testAfterLoadingTheWrappingParameterIsSet()
     {
-        $this->load();
+        $this->load(['form' => ['mapping' => ['enabled' => false]]]);
         $this->assertContainerBuilderHasParameter(
             'sonata.core.form_type'
         );
@@ -32,7 +32,10 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
 
     public function testHorizontalFormTypeMeansNoWrapping()
     {
-        $this->load(['form_type' => 'horizontal']);
+        $this->load([
+            'form' => ['mapping' => ['enabled' => false]],
+            'form_type' => 'horizontal',
+        ]);
         $this->assertContainerBuilderHasParameter(
             'sonata.core.form_type'
         );


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- the form mapping feature
```

## To do

- [x] Update the documentation (old form names might still be used in there)


## Subject

This feature allows users to use form names, just like, you know, before sf 2.8. Needless to say, we need to kill it with fire. It should have been conditionally deprecated as soon as we added support for sf 2.8