### PR TITLE
Namespaced twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/translation": "^2.8 || ^3.2",
         "symfony/twig-bridge": "^2.8 || ^3.2",
         "symfony/validator": "^2.8 || ^3.2",
-        "twig/extensions": "^1.0",
+        "twig/extensions": "^1.5",
         "twig/twig": "^1.34 || ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/exporter": "^1.3",
-        "symfony/phpunit-bridge": "^3.3"
+        "symfony/phpunit-bridge": "^3.3.12"
     },
     "autoload": {
         "psr-4": { "Sonata\\CoreBundle\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>

--- a/src/Twig/Extension/DeprecatedTextExtension.php
+++ b/src/Twig/Extension/DeprecatedTextExtension.php
@@ -11,21 +11,24 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
+use Twig\Environment;
+use Twig\Extensions\TextExtension;
+
 /**
  * NEXT_MAJOR : remove this class and the twig/extensions dependency.
  *
  * @deprecated since version 3.2, to be removed in 4.0.
  */
-final class DeprecatedTextExtension extends \Twig_Extensions_Extension_Text
+final class DeprecatedTextExtension extends TextExtension
 {
-    public function twig_truncate_filter(\Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
+    public function twig_truncate_filter(Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
     {
         $this->notifyDeprecation();
 
         return twig_truncate_filter($env, $value, $length, $preserve, $separator);
     }
 
-    public function twig_wordwrap_filter(\Twig_Environment $env, $value, $length = 80, $separator = "\n", $preserve = false)
+    public function twig_wordwrap_filter(Environment $env, $value, $length = 80, $separator = "\n", $preserve = false)
     {
         $this->notifyDeprecation();
 

--- a/src/Twig/Extension/DeprecatedTextExtension.php
+++ b/src/Twig/Extension/DeprecatedTextExtension.php
@@ -35,7 +35,8 @@ final class DeprecatedTextExtension extends \Twig_Extensions_Extension_Text
     private function notifyDeprecation()
     {
         @trigger_error(
-            'Using the sonata.core.twig.extension.text service is deprecated since 3.2 and will be removed in 4.0'
+            'Using the sonata.core.twig.extension.text service is deprecated since 3.2 and will be removed in 4.0',
+            E_USER_DEPRECATED
         );
     }
 }

--- a/src/Twig/Extension/DeprecatedTextExtension.php
+++ b/src/Twig/Extension/DeprecatedTextExtension.php
@@ -22,14 +22,14 @@ final class DeprecatedTextExtension extends \Twig_Extensions_Extension_Text
     {
         $this->notifyDeprecation();
 
-        return parent::twig_truncate_filter($env, $value, $length, $preserve, $separator);
+        return twig_truncate_filter($env, $value, $length, $preserve, $separator);
     }
 
     public function twig_wordwrap_filter(\Twig_Environment $env, $value, $length = 80, $separator = "\n", $preserve = false)
     {
         $this->notifyDeprecation();
 
-        return parent::twig_wordwrap_filter($env, $value, $length, $separator, $preserve);
+        return twig_wordwrap_filter($env, $value, $length, $separator, $preserve);
     }
 
     private function notifyDeprecation()

--- a/src/Twig/Extension/FlashMessageExtension.php
+++ b/src/Twig/Extension/FlashMessageExtension.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-use Twig\TwigFunction;
-use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\FlashMessage\FlashManager;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * This is the Sonata core flash message Twig extension.

--- a/src/Twig/Extension/FlashMessageExtension.php
+++ b/src/Twig/Extension/FlashMessageExtension.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
+use Twig\TwigFunction;
+use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\FlashMessage\FlashManager;
 
 /**
@@ -18,7 +20,7 @@ use Sonata\CoreBundle\FlashMessage\FlashManager;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class FlashMessageExtension extends \Twig_Extension
+class FlashMessageExtension extends AbstractExtension
 {
     /**
      * @var FlashManager
@@ -39,8 +41,8 @@ class FlashMessageExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sonata_flashmessages_get', [$this, 'getFlashMessages']),
-            new \Twig_SimpleFunction('sonata_flashmessages_types', [$this, 'getFlashMessagesTypes']),
+            new TwigFunction('sonata_flashmessages_get', [$this, 'getFlashMessages']),
+            new TwigFunction('sonata_flashmessages_types', [$this, 'getFlashMessagesTypes']),
         ];
     }
 

--- a/src/Twig/Extension/FormTypeExtension.php
+++ b/src/Twig/Extension/FormTypeExtension.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-class FormTypeExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+use Twig\Extension\GlobalsInterface;
+use Twig\Extension\AbstractExtension;
+class FormTypeExtension extends AbstractExtension implements GlobalsInterface
 {
     /**
      * @var bool

--- a/src/Twig/Extension/FormTypeExtension.php
+++ b/src/Twig/Extension/FormTypeExtension.php
@@ -11,8 +11,9 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-use Twig\Extension\GlobalsInterface;
 use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
 class FormTypeExtension extends AbstractExtension implements GlobalsInterface
 {
     /**

--- a/src/Twig/Extension/StatusExtension.php
+++ b/src/Twig/Extension/StatusExtension.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Twig\Extension\AbstractExtension;
 
 /**
  * @author Hugo Briand <briand@ekino.com>

--- a/src/Twig/Extension/StatusExtension.php
+++ b/src/Twig/Extension/StatusExtension.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class StatusExtension extends \Twig_Extension
+class StatusExtension extends AbstractExtension
 {
     /**
      * @var StatusClassRendererInterface[]

--- a/src/Twig/Extension/TemplateExtension.php
+++ b/src/Twig/Extension/TemplateExtension.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
 
 class TemplateExtension extends AbstractExtension
 {

--- a/src/Twig/Extension/TemplateExtension.php
+++ b/src/Twig/Extension/TemplateExtension.php
@@ -11,11 +11,12 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
 use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class TemplateExtension extends \Twig_Extension
+class TemplateExtension extends AbstractExtension
 {
     /**
      * @var bool

--- a/src/Twig/Node/TemplateBoxNode.php
+++ b/src/Twig/Node/TemplateBoxNode.php
@@ -11,9 +11,12 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
+use Twig\Node\Node;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Compiler;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class TemplateBoxNode extends \Twig_Node
+class TemplateBoxNode extends Node
 {
     /**
      * @var int
@@ -33,7 +36,7 @@ class TemplateBoxNode extends \Twig_Node
      * @param null|string           $lineno            Symfony template line number
      * @param null                  $tag               Symfony tag name
      */
-    public function __construct(\Twig_Node_Expression $message, \Twig_Node_Expression $translationBundle = null, $enabled, TranslatorInterface $translator, $lineno, $tag = null)
+    public function __construct(AbstractExpression $message, AbstractExpression $translationBundle = null, $enabled, TranslatorInterface $translator, $lineno, $tag = null)
     {
         $this->enabled = $enabled;
         $this->translator = $translator;
@@ -50,7 +53,7 @@ class TemplateBoxNode extends \Twig_Node
     /**
      * {@inheritdoc}
      */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this);

--- a/src/Twig/Node/TemplateBoxNode.php
+++ b/src/Twig/Node/TemplateBoxNode.php
@@ -11,10 +11,10 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
-use Twig\Node\Node;
-use Twig\Node\Expression\AbstractExpression;
-use Twig\Compiler;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
 
 class TemplateBoxNode extends Node
 {

--- a/src/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -11,10 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Token;
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class TemplateBoxTokenParser extends \Twig_TokenParser
+class TemplateBoxTokenParser extends AbstractTokenParser
 {
     /**
      * @var bool
@@ -39,21 +42,21 @@ class TemplateBoxTokenParser extends \Twig_TokenParser
     /**
      * {@inheritdoc}
      */
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
-        if ($this->parser->getStream()->test(\Twig_Token::STRING_TYPE)) {
+        if ($this->parser->getStream()->test(Token::STRING_TYPE)) {
             $message = $this->parser->getExpressionParser()->parseExpression();
         } else {
-            $message = new \Twig_Node_Expression_Constant('Template information', $token->getLine());
+            $message = new ConstantExpression('Template information', $token->getLine());
         }
 
-        if ($this->parser->getStream()->test(\Twig_Token::STRING_TYPE)) {
+        if ($this->parser->getStream()->test(Token::STRING_TYPE)) {
             $translationBundle = $this->parser->getExpressionParser()->parseExpression();
         } else {
             $translationBundle = null;
         }
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new TemplateBoxNode($message, $translationBundle, $this->enabled, $this->translator, $token->getLine(), $this->getTag());
     }

--- a/src/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -11,11 +11,11 @@
 
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
-use Twig\TokenParser\AbstractTokenParser;
-use Twig\Node\Expression\ConstantExpression;
-use Twig\Token;
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
 class TemplateBoxTokenParser extends AbstractTokenParser
 {

--- a/tests/Form/Type/BasePickerTypeTest.php
+++ b/tests/Form/Type/BasePickerTypeTest.php
@@ -65,7 +65,7 @@ class BasePickerTypeTest extends TestCase
      *
      * @group legacy
      */
-    public function testLegacyConstructor()
+    public function testConstructorLegacy()
     {
         new BasePickerTest(new MomentFormatConverter());
     }

--- a/tests/Form/Type/BooleanTypeTest.php
+++ b/tests/Form/Type/BooleanTypeTest.php
@@ -181,7 +181,10 @@ class BooleanTypeTest extends TypeTestCase
         $this->assertSame($expectedOptions, $resolvedOptions);
     }
 
-    public function testLegacyDeprecatedCatalogueOption()
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedCatalogueOptionLegacy()
     {
         $type = new BooleanType();
 

--- a/tests/Form/Type/DatePickerTypeTest.php
+++ b/tests/Form/Type/DatePickerTypeTest.php
@@ -97,7 +97,10 @@ class DatePickerTypeTest extends TestCase
         $this->assertSame('sonata_type_date_picker', $type->getName());
     }
 
-    public function testLegacyConstructor()
+    /**
+     * @group legacy
+     */
+    public function testConstructorLegacy()
     {
         $type = new DatePickerType(new MomentFormatConverter());
 

--- a/tests/Form/Type/DateTimePickerTypeTest.php
+++ b/tests/Form/Type/DateTimePickerTypeTest.php
@@ -101,7 +101,10 @@ class DateTimePickerTypeTest extends TestCase
         $this->assertSame('sonata_type_datetime_picker', $type->getName());
     }
 
-    public function testLegacyConstructor()
+    /**
+     * @group legacy
+     */
+    public function testConstructorLegacy()
     {
         $type = new DateTimePickerType(new MomentFormatConverter());
 

--- a/tests/Twig/Extension/DeprecatedTextExtensionTest.php
+++ b/tests/Twig/Extension/DeprecatedTextExtensionTest.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Twig/Extension/DeprecatedTextExtensionTest.php
+++ b/tests/Twig/Extension/DeprecatedTextExtensionTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Sonata\CoreBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Twig\Extension\DeprecatedTextExtension;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class DeprecatedTextExtensionTest extends TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the sonata.core.twig.extension.text service is deprecated since 3.2 and will be removed in 4.0
+     */
+    public function testDeprecation()
+    {
+        $extension = new DeprecatedTextExtension();
+        $extension->twig_truncate_filter(
+            new Environment(new ArrayLoader()),
+            'A long piece of text, well not that long actually but whatever.'
+        );
+    }
+}

--- a/tests/Twig/Extension/FlashMessageExtensionTest.php
+++ b/tests/Twig/Extension/FlashMessageExtensionTest.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Twig/Extension/FlashMessageExtensionTest.php
+++ b/tests/Twig/Extension/FlashMessageExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Sonata\CoreBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\FlashMessage\FlashManager;
+use Sonata\CoreBundle\Twig\Extension\FlashMessageExtension;
+
+class FlashMessageExtensionTest extends TestCase
+{
+    private $extension;
+
+    protected function setUp()
+    {
+        $this->extension = new FlashMessageExtension(
+            $this->prophesize(FlashManager::class)->reveal()
+        );
+    }
+
+    public function testFunctionsArePrefixed()
+    {
+        foreach ($this->extension->getFunctions() as $function) {
+            $this->assertTrue(
+                0 === strpos($function->getName(), 'sonata_flashmessages_'),
+                'All function names should start with a standard prefix'
+            );
+        }
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `twig_truncate_filter`, and `twig_wordwrap_filter` were broken
- `twig_truncate_filter`, and `twig_wordwrap_filter` were not properly deprecated
```

## Subject

The goal of this PR was to use Twig namespaces, but I found 2 bugs along the way.
