### PR TITLE
Mark form compiler pass as legacy

### DIFF
--- a/tests/DependencyInjection/Compiler/FormFactoryCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/FormFactoryCompilerPassTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ * @group legacy
  */
 final class FormFactoryCompilerPassTest extends AbstractCompilerPassTestCase
 {


### PR DESCRIPTION
It should not be used.
