### PR TITLE
Avoid autoloading deprecated compiler pass

### DIFF
--- a/src/SonataCoreBundle.php
+++ b/src/SonataCoreBundle.php
@@ -29,8 +29,15 @@ class SonataCoreBundle extends Bundle
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
 
+        $formMappingIsEnabled = true;
+        foreach ($container->getExtensionConfig('sonata_core') as $config) {
+            if (isset($config['form']['mapping']['enabled'])) {
+                // the last config wins
+                $formMappingIsEnabled = $config['form']['mapping']['enabled'];
+            }
+        }
         // NEXT_MAJOR: remove this block
-        if (class_exists(FormPass::class)) {
+        if ($formMappingIsEnabled && class_exists(FormPass::class)) {
             $container->addCompilerPass(new FormFactoryCompilerPass());
         }
 

--- a/tests/SonataCoreBundleTest.php
+++ b/tests/SonataCoreBundleTest.php
@@ -15,9 +15,11 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
+use Sonata\CoreBundle\DependencyInjection\SonataCoreExtension;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\SonataCoreBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
@@ -188,6 +190,24 @@ final class SonataCoreBundleTest extends TestCase
 
         $this->assertMappingTypeRegistered('fooMapping', 'barType');
         $this->assertMappingExtensionRegistered('fooMapping', 'barExtension');
+    }
+
+    public function testWithDisabledFormMapping()
+    {
+        $extension = new SonataCoreExtension();
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->registerExtension($extension);
+        $containerBuilder->loadFromExtension('sonata_core', ['form' => [
+            'mapping' => ['enabled' => false],
+        ]]);
+        $bundle = new SonataCoreBundle();
+        $bundle->build($containerBuilder);
+        $this->assertCount(0, array_filter(
+            $containerBuilder->getCompilerPassConfig()->getBeforeOptimizationPasses(),
+            function (CompilerPassInterface $compilerPass) {
+                return $compilerPass instanceof FormFactoryCompilerPass;
+            }
+        ));
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation about FormPass can now be avoided
```
## Subject

Testing the class existence when deciding whether to add the compiler pass was causing autoloading, which in turn triggered a deprecation. This checks the current config to avoid this behavior.
