### PR TITLE
Avoid inheritance from deprecated FormPass

### DIFF
--- a/src/DependencyInjection/Compiler/FormFactoryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormFactoryCompilerPass.php
@@ -12,12 +12,13 @@
 namespace Sonata\CoreBundle\DependencyInjection\Compiler;
 
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @deprecated since 3.7, to be removed in 4.0, the form mapping feature should be disabled.
  */
-class FormFactoryCompilerPass extends FormPass
+class FormFactoryCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
@@ -44,7 +45,7 @@ class FormFactoryCompilerPass extends FormPass
 
         // get factories
         $original = $container->getDefinition('form.extension');
-        parent::process($container);
+        $this->processFormPass($container);
 
         $factory = $container->getDefinition('sonata.core.form.extension.dependency');
         $factory->replaceArgument(1, $original->getArgument(1));
@@ -55,5 +56,11 @@ class FormFactoryCompilerPass extends FormPass
         $container->removeDefinition('sonata.core.form.extension.dependency');
 
         $container->setDefinition('form.extension', $factory);
+    }
+
+    private function processFormPass(ContainerBuilder $container)
+    {
+        $formPass = new FormPass();
+        $formPass->process($container);
     }
 }

--- a/src/SonataCoreBundle.php
+++ b/src/SonataCoreBundle.php
@@ -28,18 +28,7 @@ class SonataCoreBundle extends Bundle
     {
         $container->addCompilerPass(new StatusRendererCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
-
-        $formMappingIsEnabled = true;
-        foreach ($container->getExtensionConfig('sonata_core') as $config) {
-            if (isset($config['form']['mapping']['enabled'])) {
-                // the last config wins
-                $formMappingIsEnabled = $config['form']['mapping']['enabled'];
-            }
-        }
-        // NEXT_MAJOR: remove this block
-        if ($formMappingIsEnabled && class_exists(FormPass::class)) {
-            $container->addCompilerPass(new FormFactoryCompilerPass());
-        }
+        $container->addCompilerPass(new FormFactoryCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/tests/SonataCoreBundleTest.php
+++ b/tests/SonataCoreBundleTest.php
@@ -192,24 +192,6 @@ final class SonataCoreBundleTest extends TestCase
         $this->assertMappingExtensionRegistered('fooMapping', 'barExtension');
     }
 
-    public function testWithDisabledFormMapping()
-    {
-        $extension = new SonataCoreExtension();
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->registerExtension($extension);
-        $containerBuilder->loadFromExtension('sonata_core', ['form' => [
-            'mapping' => ['enabled' => false],
-        ]]);
-        $bundle = new SonataCoreBundle();
-        $bundle->build($containerBuilder);
-        $this->assertCount(0, array_filter(
-            $containerBuilder->getCompilerPassConfig()->getBeforeOptimizationPasses(),
-            function (CompilerPassInterface $compilerPass) {
-                return $compilerPass instanceof FormFactoryCompilerPass;
-            }
-        ));
-    }
-
     /**
      * Asserts mapping type registered.
      *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because after many labors we did not manage to get rid of the deprecation message.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Relates #489 #471 #412 sonata-project/SonataAdminBundle#4700

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Avoid inheritance from deprecated FormPass
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
<!-- Describe your Pull Request content here -->
