### PR TITLE
Mark form type services as deprecated

### DIFF
--- a/src/Form/Type/TranslatableChoiceType.php
+++ b/src/Form/Type/TranslatableChoiceType.php
@@ -19,6 +19,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
+@trigger_error(
+    sprintf(
+        'Form type "%s" is deprecated since SonataCoreBundle 2.2.0 and will be'
+        .' removed in 4.0. Use form type "%s" with "translation_domain" option instead.',
+        TranslatableChoiceType::class,
+        ChoiceType::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
  * NEXT_MAJOR: remove this class.
  *
@@ -37,12 +47,6 @@ class TranslatableChoiceType extends AbstractType
      */
     public function __construct(TranslatorInterface $translator)
     {
-        @trigger_error(
-            'Form type "sonata_type_translatable_choice" is deprecated since SonataCoreBundle 2.2.0 and will be'
-            .' removed in 4.0. Use form type "choice" with "translation_domain" option instead.',
-            E_USER_DEPRECATED
-        );
-
         $this->translator = $translator;
     }
 

--- a/src/Resources/config/form_types.xml
+++ b/src/Resources/config/form_types.xml
@@ -11,6 +11,7 @@
             <tag name="form.type" alias="sonata_type_collection"/>
         </service>
         <service id="sonata.core.form.type.translatable_choice" class="Sonata\CoreBundle\Form\Type\TranslatableChoiceType">
+            <deprecated>The "%service_id%" service is deprecated since 2.2.0 and will be removed in 4.0.</deprecated>
             <tag name="form.type" alias="sonata_type_translatable_choice"/>
             <argument type="service" id="translator"/>
         </service>
@@ -45,6 +46,7 @@
             <argument type="service" id="translator"/>
         </service>
         <service id="sonata.core.form.type.color_selector" class="Sonata\CoreBundle\Form\Type\ColorSelectorType">
+            <deprecated>The "%service_id%" service is deprecated since 3.5 and will be removed in 4.0.</deprecated>
             <tag name="form.type" alias="sonata_type_color_selector"/>
         </service>
         <service id="sonata.core.form.type.color" class="Sonata\CoreBundle\Form\Type\ColorType">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because deprecated classes trigger notification if according services are not marked as deprecated.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed deprecation message in `ColorSelectorType`
```
