### PR TITLE
Add twig extension for deprecating templates

### DIFF
--- a/docs/reference/twig_helpers.rst
+++ b/docs/reference/twig_helpers.rst
@@ -29,3 +29,17 @@ sonata_urlsafeid
 
 Gets the identifiers of the object as a string that is safe to use in an url.
 
+sonata_template_deprecate
+-------------------------
+Node that can be used to deprecate a template. You have to provide a string that represents a new template and
+this argument is mandatory.
+
+.. code-block:: jinja
+
+    {% sonata_template_deprecate 'new_template.html.twig' %}
+
+Triggers deprecation with a message: ::
+
+    The "current_template.html.twig" template is deprecated. Use "new_template.html.twig" instead.
+
+In this example we used ``{% sonata_template_deprecate 'new_template.html.twig' %}`` inside of ``current_template.html.twig`` template.

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -12,6 +12,9 @@
         <service id="sonata.core.twig.status_extension" class="Sonata\CoreBundle\Twig\Extension\StatusExtension">
             <tag name="twig.extension"/>
         </service>
+        <service id="sonata.core.twig.deprecated_template_extension" class="Sonata\CoreBundle\Twig\Extension\DeprecatedTemplateExtension">
+            <tag name="twig.extension"/>
+        </service>
         <service id="sonata.core.twig.template_extension" class="Sonata\CoreBundle\Twig\Extension\TemplateExtension">
             <tag name="twig.extension"/>
             <argument>%kernel.debug%</argument>

--- a/src/Twig/Extension/DeprecatedTemplateExtension.php
+++ b/src/Twig/Extension/DeprecatedTemplateExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Twig\Extension;
+
+use Sonata\CoreBundle\Twig\TokenParser\DeprecatedTemplateTokenParser;
+use Twig\Extension\AbstractExtension;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class DeprecatedTemplateExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenParsers()
+    {
+        return [
+            new DeprecatedTemplateTokenParser(),
+        ];
+    }
+}

--- a/src/Twig/Node/DeprecatedTemplateNode.php
+++ b/src/Twig/Node/DeprecatedTemplateNode.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Twig\Node;
+
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class DeprecatedTemplateNode extends Node
+{
+    public function __construct(AbstractExpression $newTemplate, $line, $tag = null)
+    {
+        parent::__construct(['newTemplate' => $newTemplate], [], $line, $tag);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile(Compiler $compiler)
+    {
+        @trigger_error(sprintf(
+            'The "%s" template is deprecated. Use "%s" instead.',
+            $this->getTemplateName(),
+            $this->getNode('newTemplate')->getAttribute('value')
+        ), E_USER_DEPRECATED);
+    }
+}

--- a/src/Twig/TokenParser/DeprecatedTemplateTokenParser.php
+++ b/src/Twig/TokenParser/DeprecatedTemplateTokenParser.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Twig\TokenParser;
+
+use Sonata\CoreBundle\Twig\Node\DeprecatedTemplateNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class DeprecatedTemplateTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token)
+    {
+        if (!$this->parser->getStream()->test(Token::STRING_TYPE)) {
+            throw new \InvalidArgumentException('New template name is mandatory.');
+        }
+
+        $newTemplate = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+
+        return new DeprecatedTemplateNode($newTemplate, $token->getLine(), $this->getTag());
+    }
+
+    public function getTag()
+    {
+        return 'sonata_template_deprecate';
+    }
+}

--- a/tests/Twig/Node/DeprecatedTemplateNodeTest.php
+++ b/tests/Twig/Node/DeprecatedTemplateNodeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Twig\Node;
+
+use Sonata\CoreBundle\Twig\Node\DeprecatedTemplateNode;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Test\NodeTestCase;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+class DeprecatedTemplateNodeTest extends NodeTestCase
+{
+    public function testConstructor()
+    {
+        $body = $this->getNode();
+
+        $this->assertSame(1, $body->getTemplateLine());
+    }
+
+    /**
+     * @expectedDeprecation The "" template is deprecated. Use "new.html.twig" instead.
+     * @group legacy
+     * @dataProvider getTests
+     */
+    public function testCompile($node, $source, $environment = null, $isPattern = false)
+    {
+        parent::testCompile($node, $source, $environment, $isPattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return [
+            [$this->getNode(), null],
+        ];
+    }
+
+    private function getNode()
+    {
+        return new DeprecatedTemplateNode(
+            new ConstantExpression('new.html.twig', 1),
+            1,
+            'sonata_template_deprecate'
+        );
+    }
+}

--- a/tests/Twig/TokenParser/DeprecatedTemplateTokenParserTest.php
+++ b/tests/Twig/TokenParser/DeprecatedTemplateTokenParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Twig\TokenParser;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Twig\Node\DeprecatedTemplateNode;
+use Sonata\CoreBundle\Twig\TokenParser\DeprecatedTemplateTokenParser;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Parser;
+use Twig\Source;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+class DeprecatedTemplateTokenParserTest extends TestCase
+{
+    public function testCompileValid()
+    {
+        $source = new Source('{% sonata_template_deprecate "new.html.twig" %}', 'test');
+        $expected = new DeprecatedTemplateNode(
+            new ConstantExpression('new.html.twig', 1),
+            1,
+            'sonata_template_deprecate'
+        );
+
+        $actual = $this->compile($source);
+
+        $this->assertSame(
+            $expected->getIterator()->getFlags(),
+            $actual->getIterator()->getFlags()
+        );
+
+        $this->assertSame($expected->getTemplateLine(), $actual->getTemplateLine());
+        $this->assertSame($expected->count(), $actual->count());
+    }
+
+    public function testCompileException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $source = new Source('{% sonata_template_deprecate %}', 'test');
+
+        $this->compile($source);
+    }
+
+    private function compile(Source $source)
+    {
+        $env = new Environment(new ArrayLoader([]), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
+        $env->addTokenParser(new DeprecatedTemplateTokenParser());
+
+        $stream = $env->tokenize($source);
+        $parser = new Parser($env);
+
+        return $parser->parse($stream)->getNode('body')->getNode(0);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding a twig function for deprecating templates, needed for https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/772 and https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/258

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added twig extension for deprecating templates
```

## To do

- [x] Add tests
- [x] Update documentation
## Subject

We needed a way to deprecate old templates, this is used for https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/772 and https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/258 as suggested it is better to be in this bundle than in `SonataAdminBundle`.