### PR TITLE
Always flip choices in BaseStatusType

### DIFF
--- a/src/Form/Type/BaseStatusType.php
+++ b/src/Form/Type/BaseStatusType.php
@@ -13,7 +13,6 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -104,7 +103,7 @@ abstract class BaseStatusType extends AbstractType
         $choices = call_user_func([$this->class, $this->getter]);
 
         // choice_as_value options is not needed in SF 3.0+
-        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+        if ($resolver->isDefined('choices_as_values')) {
             $resolver->setDefault('choices_as_values', true);
         }
 

--- a/src/Form/Type/BaseStatusType.php
+++ b/src/Form/Type/BaseStatusType.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -44,8 +45,17 @@ abstract class BaseStatusType extends AbstractType
      * @param string $name
      * @param bool   $flip   reverse key/value to match sf2.8 and sf3.0 change
      */
-    public function __construct($class, $getter, $name, $flip = false)
+    public function __construct($class, $getter, $name, $flip = null)
     {
+        if (null === $flip) {
+            $flip = true;
+        } else {
+            @trigger_error(
+                'Calling '.__CLASS__.' class with a flip parameter is deprecated since 3.x, to be removed with 4.0',
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->class = $class;
         $this->getter = $getter;
         $this->name = $name;
@@ -93,6 +103,12 @@ abstract class BaseStatusType extends AbstractType
     {
         $choices = call_user_func([$this->class, $this->getter]);
 
+        // choice_as_value options is not needed in SF 3.0+
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+            $resolver->setDefault('choices_as_values', true);
+        }
+
+        // NEXT_MAJOR: remove this property
         if ($this->flip) {
             $count = count($choices);
 

--- a/tests/Form/Type/StatusTypeTest.php
+++ b/tests/Form/Type/StatusTypeTest.php
@@ -61,6 +61,29 @@ class StatusTypeTest extends TypeTestCase
         $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testGetDefaultOptionsLegacy()
+    {
+        Choice::$list = [
+            1 => 'salut',
+        ];
+
+        $type = new StatusType(Choice::class, 'getList', 'choice_type', false);
+
+        $this->assertSame('choice_type', $type->getName());
+
+        $this->assertSame(ChoiceType::class, $type->getParent());
+
+        FormHelper::configureOptions($type, $resolver = new OptionsResolver());
+
+        $options = $resolver->resolve([]);
+
+        $this->assertArrayHasKey('choices', $options);
+        $this->assertSame($options['choices'], [1 => 'salut']);
+    }
+
     public function testGetDefaultOptions()
     {
         Choice::$list = [
@@ -78,7 +101,7 @@ class StatusTypeTest extends TypeTestCase
         $options = $resolver->resolve([]);
 
         $this->assertArrayHasKey('choices', $options);
-        $this->assertSame($options['choices'], [1 => 'salut']);
+        $this->assertSame($options['choices'], ['salut' => 1]);
     }
 
     public function testGetDefaultOptionsWithValidFlip()
@@ -88,7 +111,7 @@ class StatusTypeTest extends TypeTestCase
             2 => 'toi!',
         ];
 
-        $type = new StatusType(Choice::class, 'getList', 'choice_type', true);
+        $type = new StatusType(Choice::class, 'getList', 'choice_type');
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(ChoiceType::class, $type->getParent());
@@ -110,13 +133,13 @@ class StatusTypeTest extends TypeTestCase
             2 => 'error',
         ];
 
-        $type = new StatusType(Choice::class, 'getList', 'choice_type', true);
+        $type = new StatusType(Choice::class, 'getList', 'choice_type');
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(ChoiceType::class, $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
-        $options = $resolver->resolve([]);
+        $resolver->resolve([]);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix, but also a soft BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Always flip choices in `BaseStatusType`
```


## Subject

The commit https://github.com/sonata-project/SonataCoreBundle/commit/1eefe7607bbf20ad5ef401febbde6110fb9269f2#diff-c25f4304e73e2ac2efcf019f17558604 introduced a wrong approach which will cause some problems when using symfony 3.
