### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/DependencyInjection/SonataCoreExtension.php
+++ b/src/DependencyInjection/SonataCoreExtension.php
@@ -11,7 +11,15 @@
 
 namespace Sonata\CoreBundle\DependencyInjection;
 
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
+use Sonata\CoreBundle\Form\Type\DateRangeType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType;
+use Sonata\CoreBundle\Form\Type\EqualType;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
 use Sonata\CoreBundle\Serializer\BaseSerializerHandler;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\Config\Definition\Processor;
@@ -52,7 +60,7 @@ class SonataCoreExtension extends Extension implements PrependExtensionInterface
         $configuration = new Configuration();
 
         // NEXT_MAJOR : remove this if block
-        if (!interface_exists('JMS\Serializer\Handler\SubscribingHandlerInterface')) {
+        if (!interface_exists(SubscribingHandlerInterface::class)) {
             /* Let's check for config values before the configuration is processed,
              * otherwise we won't be able to tell,
              * since there is a default value for this option. */
@@ -96,13 +104,13 @@ EOT
     public function configureClassesToCompile()
     {
         $this->addClassesToCompile([
-            'Sonata\\CoreBundle\\Form\\Type\\BooleanType',
-            'Sonata\\CoreBundle\\Form\\Type\\CollectionType',
-            'Sonata\\CoreBundle\\Form\\Type\\DateRangeType',
-            'Sonata\\CoreBundle\\Form\\Type\\DateTimeRangeType',
-            'Sonata\\CoreBundle\\Form\\Type\\EqualType',
-            'Sonata\\CoreBundle\\Form\\Type\\ImmutableArrayType',
-            'Sonata\\CoreBundle\\Form\\Type\\TranslatableChoiceType',
+            BooleanType::class,
+            CollectionType::class,
+            DateRangeType::class,
+            DateTimeRangeType::class,
+            EqualType::class,
+            ImmutableArrayType::class,
+            TranslatableChoiceType::class,
         ]);
     }
 
@@ -185,7 +193,7 @@ EOT
      */
     public function configureSerializerFormats($config)
     {
-        if (interface_exists('JMS\Serializer\Handler\SubscribingHandlerInterface')) {
+        if (interface_exists(SubscribingHandlerInterface::class)) {
             BaseSerializerHandler::setFormats($config['serializer']['formats']);
         }
     }

--- a/src/Form/EventListener/FixCheckboxDataListener.php
+++ b/src/Form/EventListener/FixCheckboxDataListener.php
@@ -45,7 +45,7 @@ class FixCheckboxDataListener implements EventSubscriberInterface
     public function preBind(FormEvent $event)
     {
         // BC prevention for class extending this one.
-        if ('Sonata\CoreBundle\Form\EventListener\FixCheckboxDataListener' !== get_called_class()) {
+        if (self::class !== get_called_class()) {
             @trigger_error(
                 __METHOD__.' is deprecated since 2.3 and will be renamed in 4.0.'
                 .' Use '.__CLASS__.'::preSubmit instead.',

--- a/src/Form/EventListener/ResizeFormListener.php
+++ b/src/Form/EventListener/ResizeFormListener.php
@@ -121,7 +121,7 @@ class ResizeFormListener implements EventSubscriberInterface
     public function preBind(FormEvent $event)
     {
         // BC prevention for class extending this one.
-        if ('Sonata\CoreBundle\Form\EventListener\ResizeFormListener' !== get_called_class()) {
+        if (self::class !== get_called_class()) {
             @trigger_error(
                 __METHOD__.' method is deprecated since 2.3 and will be renamed in 4.0.'
                 .' Use '.__CLASS__.'::preSubmit instead.',
@@ -192,7 +192,7 @@ class ResizeFormListener implements EventSubscriberInterface
     public function onBind(FormEvent $event)
     {
         // BC prevention for class extending this one.
-        if ('Sonata\CoreBundle\Form\EventListener\ResizeFormListener' !== get_called_class()) {
+        if (self::class !== get_called_class()) {
             @trigger_error(
                 __METHOD__.' is deprecated since 2.3 and will be renamed in 4.0.'
                 .' Use '.__CLASS__.'::onSubmit instead.',

--- a/src/Form/Extension/DependencyInjectionExtension.php
+++ b/src/Form/Extension/DependencyInjectionExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormTypeGuesserChain;
 use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * This proxy class help to keep BC code with < SF2.8 form behavior by restoring
@@ -100,7 +101,7 @@ class DependencyInjectionExtension implements FormExtensionInterface
         $name = self::findClass($this->mappingTypes, $name);
 
         if (!isset($this->typeServiceIds[$name])) {
-            if (class_exists($name) && in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name), true)) {
+            if (class_exists($name) && in_array(FormTypeInterface::class, class_implements($name), true)) {
                 return new $name();
             }
 

--- a/src/Form/Type/DateRangeType.php
+++ b/src/Form/Type/DateRangeType.php
@@ -39,7 +39,7 @@ class DateRangeType extends AbstractType
     public function __construct(TranslatorInterface $translator = null)
     {
         // check if class is overloaded and notify about removing deprecated translator
-        if (null !== $translator && __CLASS__ !== get_class($this) && 'Sonata\CoreBundle\Form\Type\DateRangePickerType' !== get_class($this)) {
+        if (null !== $translator && __CLASS__ !== get_class($this) && DateRangePickerType::class !== get_class($this)) {
             @trigger_error(
                 'The translator dependency in '.__CLASS__.' is deprecated since 3.1 and will be removed in 4.0. '.
                 'Please prepare your dependencies for this change.',

--- a/src/Form/Type/DateTimeRangeType.php
+++ b/src/Form/Type/DateTimeRangeType.php
@@ -39,7 +39,7 @@ class DateTimeRangeType extends AbstractType
     public function __construct(TranslatorInterface $translator = null)
     {
         // check if class is overloaded and notify about removing deprecated translator
-        if (null !== $translator && __CLASS__ !== get_class($this) && 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType' !== get_class($this)) {
+        if (null !== $translator && __CLASS__ !== get_class($this) && DateTimeRangePickerType::class !== get_class($this)) {
             @trigger_error(
                 'The translator dependency in '.__CLASS__.' is deprecated since 3.1 and will be removed in 4.0. '.
                 'Please prepare your dependencies for this change.',

--- a/src/SonataCoreBundle.php
+++ b/src/SonataCoreBundle.php
@@ -11,11 +11,56 @@
 
 namespace Sonata\CoreBundle;
 
+use Nelmio\ApiDocBundle\Form\Extension\DescriptionFormTypeExtension;
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
+use Sonata\CoreBundle\Form\Type\ColorSelectorType;
+use Sonata\CoreBundle\Form\Type\ColorType;
+use Sonata\CoreBundle\Form\Type\DatePickerType;
+use Sonata\CoreBundle\Form\Type\DateRangePickerType;
+use Sonata\CoreBundle\Form\Type\DateRangeType;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType;
+use Sonata\CoreBundle\Form\Type\EqualType;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\ResetType;
+use Symfony\Component\Form\Extension\Core\Type\SearchType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataCoreBundle extends Bundle
@@ -48,54 +93,54 @@ class SonataCoreBundle extends Bundle
     {
         // symfony
         FormHelper::registerFormTypeMapping([
-            'form' => 'Symfony\Component\Form\Extension\Core\Type\FormType',
-            'birthday' => 'Symfony\Component\Form\Extension\Core\Type\BirthdayType',
-            'checkbox' => 'Symfony\Component\Form\Extension\Core\Type\CheckboxType',
-            'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-            'collection' => 'Symfony\Component\Form\Extension\Core\Type\CollectionType',
-            'country' => 'Symfony\Component\Form\Extension\Core\Type\CountryType',
-            'date' => 'Symfony\Component\Form\Extension\Core\Type\DateType',
-            'datetime' => 'Symfony\Component\Form\Extension\Core\Type\DateTimeType',
-            'email' => 'Symfony\Component\Form\Extension\Core\Type\EmailType',
-            'file' => 'Symfony\Component\Form\Extension\Core\Type\FileType',
-            'hidden' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
-            'integer' => 'Symfony\Component\Form\Extension\Core\Type\IntegerType',
-            'language' => 'Symfony\Component\Form\Extension\Core\Type\LanguageType',
-            'locale' => 'Symfony\Component\Form\Extension\Core\Type\LocaleType',
-            'money' => 'Symfony\Component\Form\Extension\Core\Type\MoneyType',
-            'number' => 'Symfony\Component\Form\Extension\Core\Type\NumberType',
-            'password' => 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
-            'percent' => 'Symfony\Component\Form\Extension\Core\Type\PercentType',
-            'radio' => 'Symfony\Component\Form\Extension\Core\Type\RadioType',
-            'repeated' => 'Symfony\Component\Form\Extension\Core\Type\RepeatedType',
-            'search' => 'Symfony\Component\Form\Extension\Core\Type\SearchType',
-            'textarea' => 'Symfony\Component\Form\Extension\Core\Type\TextareaType',
-            'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'time' => 'Symfony\Component\Form\Extension\Core\Type\TimeType',
-            'timezone' => 'Symfony\Component\Form\Extension\Core\Type\TimezoneType',
-            'url' => 'Symfony\Component\Form\Extension\Core\Type\UrlType',
-            'button' => 'Symfony\Component\Form\Extension\Core\Type\ButtonType',
-            'submit' => 'Symfony\Component\Form\Extension\Core\Type\SubmitType',
-            'reset' => 'Symfony\Component\Form\Extension\Core\Type\ResetType',
-            'currency' => 'Symfony\Component\Form\Extension\Core\Type\CurrencyType',
-            'entity' => 'Symfony\Bridge\Doctrine\Form\Type\EntityType',
+            'form' => FormType::class,
+            'birthday' => BirthdayType::class,
+            'checkbox' => CheckboxType::class,
+            'choice' => ChoiceType::class,
+            'collection' => SymfonyCollectionType::class,
+            'country' => CountryType::class,
+            'date' => DateType::class,
+            'datetime' => DateTimeType::class,
+            'email' => EmailType::class,
+            'file' => FileType::class,
+            'hidden' => HiddenType::class,
+            'integer' => IntegerType::class,
+            'language' => LanguageType::class,
+            'locale' => LocaleType::class,
+            'money' => MoneyType::class,
+            'number' => NumberType::class,
+            'password' => PasswordType::class,
+            'percent' => PercentType::class,
+            'radio' => RadioType::class,
+            'repeated' => RepeatedType::class,
+            'search' => SearchType::class,
+            'textarea' => TextareaType::class,
+            'text' => TextType::class,
+            'time' => TimeType::class,
+            'timezone' => TimezoneType::class,
+            'url' => UrlType::class,
+            'button' => ButtonType::class,
+            'submit' => SubmitType::class,
+            'reset' => ResetType::class,
+            'currency' => CurrencyType::class,
+            'entity' => EntityType::class,
         ]);
 
         // core bundle
         FormHelper::registerFormTypeMapping([
-            'sonata_type_immutable_array' => 'Sonata\CoreBundle\Form\Type\ImmutableArrayType',
-            'sonata_type_boolean' => 'Sonata\CoreBundle\Form\Type\BooleanType',
-            'sonata_type_collection' => 'Sonata\CoreBundle\Form\Type\CollectionType',
-            'sonata_type_translatable_choice' => 'Sonata\CoreBundle\Form\Type\TranslatableChoiceType',
-            'sonata_type_date_range' => 'Sonata\CoreBundle\Form\Type\DateRangeType',
-            'sonata_type_datetime_range' => 'Sonata\CoreBundle\Form\Type\DateTimeRangeType',
-            'sonata_type_date_picker' => 'Sonata\CoreBundle\Form\Type\DatePickerType',
-            'sonata_type_datetime_picker' => 'Sonata\CoreBundle\Form\Type\DateTimePickerType',
-            'sonata_type_date_range_picker' => 'Sonata\CoreBundle\Form\Type\DateRangePickerType',
-            'sonata_type_datetime_range_picker' => 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType',
-            'sonata_type_equal' => 'Sonata\CoreBundle\Form\Type\EqualType',
-            'sonata_type_color' => 'Sonata\CoreBundle\Form\Type\ColorType',
-            'sonata_type_color_selector' => 'Sonata\CoreBundle\Form\Type\ColorSelectorType',
+            'sonata_type_immutable_array' => ImmutableArrayType::class,
+            'sonata_type_boolean' => BooleanType::class,
+            'sonata_type_collection' => CollectionType::class,
+            'sonata_type_translatable_choice' => TranslatableChoiceType::class,
+            'sonata_type_date_range' => DateRangeType::class,
+            'sonata_type_datetime_range' => DateTimeRangeType::class,
+            'sonata_type_date_picker' => DatePickerType::class,
+            'sonata_type_datetime_picker' => DateTimePickerType::class,
+            'sonata_type_date_range_picker' => DateRangePickerType::class,
+            'sonata_type_datetime_range_picker' => DateTimeRangePickerType::class,
+            'sonata_type_equal' => EqualType::class,
+            'sonata_type_color' => ColorType::class,
+            'sonata_type_color_selector' => ColorSelectorType::class,
         ]);
 
         $formTypes = [
@@ -105,7 +150,7 @@ class SonataCoreBundle extends Bundle
             'form.type_extension.form.data_collector',
         ];
 
-        if (class_exists('Nelmio\ApiDocBundle\Form\Extension\DescriptionFormTypeExtension')) {
+        if (class_exists(DescriptionFormTypeExtension::class)) {
             $formTypes[] = 'nelmio_api_doc.form.extension.description_form_type_extension';
         }
 

--- a/src/Test/AbstractWidgetTestCase.php
+++ b/src/Test/AbstractWidgetTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Test;
 
+use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
@@ -51,7 +52,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         parent::setUp();
 
         // TODO: remove the condition when dropping symfony/twig-bundle < 3.2
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             $this->extension = new FormExtension();
             $environment = $this->getEnvironment();
             $this->renderer = new FormRenderer(
@@ -134,7 +135,7 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
     protected function getRenderingEngine(/* \Twig_Environment $environment = null */)
     {
         $environment = current(func_get_args());
-        if (null === $environment && method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (null === $environment && method_exists(AppVariable::class, 'getToken')) {
             @trigger_error(
                 'Not passing a \Twig_Environment instance to '.__METHOD__.
                 ' is deprecated since 3.3 and will not be possible in 4.0',

--- a/src/Test/EntityManagerMockFactory.php
+++ b/src/Test/EntityManagerMockFactory.php
@@ -11,7 +11,12 @@
 
 namespace Sonata\CoreBundle\Test;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Version;
 
 class EntityManagerMockFactory
@@ -25,15 +30,15 @@ class EntityManagerMockFactory
      */
     public static function create(\PHPUnit\Framework\TestCase $test, \Closure $qbCallback, $fields)
     {
-        $query = $test->getMockBuilder('Doctrine\ORM\AbstractQuery')
+        $query = $test->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()->getMock();
         $query->expects($test->any())->method('execute')->will($test->returnValue(true));
 
         if (Version::compare('2.5.0') < 1) {
-            $entityManager = $test->getMockBuilder('Doctrine\ORM\EntityManagerInterface')->getMock();
-            $qb = $test->getMockBuilder('Doctrine\ORM\QueryBuilder')->setConstructorArgs([$entityManager])->getMock();
+            $entityManager = $test->getMockBuilder(EntityManagerInterface::class)->getMock();
+            $qb = $test->getMockBuilder(QueryBuilder::class)->setConstructorArgs([$entityManager])->getMock();
         } else {
-            $qb = $test->getMockBuilder('Doctrine\ORM\QueryBuilder')->disableOriginalConstructor()->getMock();
+            $qb = $test->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
         }
 
         $qb->expects($test->any())->method('select')->will($test->returnValue($qb));
@@ -45,14 +50,14 @@ class EntityManagerMockFactory
 
         $qbCallback($qb);
 
-        $repository = $test->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
+        $repository = $test->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
         $repository->expects($test->any())->method('createQueryBuilder')->will($test->returnValue($qb));
 
-        $metadata = $test->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')->getMock();
+        $metadata = $test->getMockBuilder(ClassMetadata::class)->getMock();
         $metadata->expects($test->any())->method('getFieldNames')->will($test->returnValue($fields));
         $metadata->expects($test->any())->method('getName')->will($test->returnValue('className'));
 
-        $em = $test->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
+        $em = $test->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
         $em->expects($test->any())->method('getRepository')->will($test->returnValue($repository));
         $em->expects($test->any())->method('getClassMetadata')->will($test->returnValue($metadata));
 

--- a/tests/DependencyInjection/SonataCoreExtensionTest.php
+++ b/tests/DependencyInjection/SonataCoreExtensionTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\CoreBundle\DependencyInjection\SonataCoreExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SonataCoreExtensionTest extends AbstractExtensionTestCase
 {
@@ -49,9 +50,7 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
 
     public function testPrepend()
     {
-        $containerBuilder = $this->prophesize(
-            'Symfony\Component\DependencyInjection\ContainerBuilder'
-        );
+        $containerBuilder = $this->prophesize(ContainerBuilder::class);
 
         $containerBuilder->getExtensionConfig('sonata_admin')->willReturn([
             ['some_key_we_do_not_care_about' => 42],

--- a/tests/Exporter/ExporterTest.php
+++ b/tests/Exporter/ExporterTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\CoreBundle\Tests\Exporter;
 
 use Exporter\Source\ArraySourceIterator;
+use Exporter\Source\SourceIteratorInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Exporter\Exporter;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -26,7 +28,7 @@ class ExporterTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $source = $this->createMock('Exporter\Source\SourceIteratorInterface');
+        $source = $this->createMock(SourceIteratorInterface::class);
 
         $exporter = new Exporter();
         $exporter->getResponse('foo', 'foo', $source);
@@ -44,7 +46,7 @@ class ExporterTest extends TestCase
         $exporter = new Exporter();
         $response = $exporter->getResponse($format, $filename, $source);
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($contentType, $response->headers->get('Content-Type'));
         $this->assertSame('attachment; filename="'.$filename.'"', $response->headers->get('Content-Disposition'));
     }

--- a/tests/FlashMessage/FlashManagerTest.php
+++ b/tests/FlashMessage/FlashManagerTest.php
@@ -73,7 +73,7 @@ class FlashManagerTest extends TestCase
         $session = $this->flashManager->getSession();
 
         // Then
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Session\Session', $session);
+        $this->assertInstanceOf(Session::class, $session);
     }
 
     public function testGetHandledTypes()

--- a/tests/Form/EventListener/ResizeFormListenerTest.php
+++ b/tests/Form/EventListener/ResizeFormListenerTest.php
@@ -13,6 +13,8 @@ namespace Sonata\CoreBundle\Tests\Form\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Form\EventListener\ResizeFormListener;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -37,7 +39,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], false, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator());
@@ -57,7 +59,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator());
@@ -71,11 +73,11 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], false, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
 
         $event = new FormEvent($form, '');
 
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectException(UnexpectedTypeException::class);
 
         $listener->preSetData($event);
     }
@@ -94,7 +96,7 @@ class ResizeFormListenerTest extends TestCase
             'default' => 'option',
         ];
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator(['foo' => 'bar']));
@@ -116,7 +118,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], false, null);
 
-        $event = $this->getMockBuilder('Symfony\Component\Form\FormEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder(FormEvent::class)->disableOriginalConstructor()->getMock();
         $event->expects($this->never())
             ->method('getForm');
 
@@ -127,7 +129,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator(['foo' => 'bar']));
@@ -143,11 +145,11 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
 
         $event = new FormEvent($form, 123);
 
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectException(UnexpectedTypeException::class);
 
         $listener->preSubmit($event);
     }
@@ -165,7 +167,7 @@ class ResizeFormListenerTest extends TestCase
             'default' => 'option',
         ];
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator(['foo' => 'bar']));
@@ -203,7 +205,7 @@ class ResizeFormListenerTest extends TestCase
             'data' => 'caz',
         ];
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator(['foo' => 'bar']));
@@ -227,9 +229,9 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
 
-        $event = $this->getMockBuilder('Symfony\Component\Form\FormEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder(FormEvent::class)->disableOriginalConstructor()->getMock();
         $event->expects($this->once())
             ->method('getForm')
             ->willReturn($form);
@@ -247,7 +249,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], false, null);
 
-        $event = $this->getMockBuilder('Symfony\Component\Form\FormEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder(FormEvent::class)->disableOriginalConstructor()->getMock();
         $event->expects($this->never())
             ->method('getForm');
 
@@ -258,7 +260,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->never())
             ->method('has');
 
@@ -271,11 +273,11 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
 
         $event = new FormEvent($form, 123);
 
-        $this->expectException('Symfony\Component\Form\Exception\UnexpectedTypeException');
+        $this->expectException(UnexpectedTypeException::class);
 
         $listener->onSubmit($event);
     }
@@ -284,12 +286,12 @@ class ResizeFormListenerTest extends TestCase
     {
         $listener = new ResizeFormListener('form', [], true, null);
 
-        $reflector = new \ReflectionClass('Sonata\CoreBundle\Form\EventListener\ResizeFormListener');
+        $reflector = new \ReflectionClass(ResizeFormListener::class);
         $reflectedMethod = $reflector->getProperty('removed');
         $reflectedMethod->setAccessible(true);
         $reflectedMethod->setValue($listener, ['foo']);
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->at(2))
             ->method('has')
             ->with('baz')
@@ -305,7 +307,7 @@ class ResizeFormListenerTest extends TestCase
             'baz' => 'baz-value',
         ];
 
-        $event = $this->getMockBuilder('Symfony\Component\Form\FormEvent')->disableOriginalConstructor()->getMock();
+        $event = $this->getMockBuilder(FormEvent::class)->disableOriginalConstructor()->getMock();
         $event->expects($this->once())
             ->method('getForm')
             ->willReturn($form);

--- a/tests/Form/Extension/DependencyInjectionExtensionTest.php
+++ b/tests/Form/Extension/DependencyInjectionExtensionTest.php
@@ -13,15 +13,19 @@ namespace Sonata\CoreBundle\Tests\Form\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormTypeInterface;
 
 class DependencyInjectionExtensionTest extends TestCase
 {
     public function testValidType()
     {
-        $type = $this->createMock('Symfony\Component\Form\FormTypeInterface');
+        $type = $this->createMock(FormTypeInterface::class);
         $formName = get_class($type);
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('has')->will($this->returnValue(true));
         $container->expects($this->any())
             ->method('get')
@@ -43,16 +47,16 @@ class DependencyInjectionExtensionTest extends TestCase
 
     public function testTypeWithoutService()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $f = new DependencyInjectionExtension($container, [], [], [], []);
 
-        $this->assertInstanceOf('Symfony\Component\Form\Extension\Core\Type\HiddenType', $f->getType('Symfony\Component\Form\Extension\Core\Type\HiddenType'));
+        $this->assertInstanceOf(HiddenType::class, $f->getType(HiddenType::class));
     }
 
     public function testTypeExtensionsValid()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->any())->method('has')->will($this->returnValue(true));
         $container->expects($this->any())
             ->method('get')
@@ -64,13 +68,13 @@ class DependencyInjectionExtensionTest extends TestCase
 
         $typeServiceIds = [];
         $typeExtensionServiceIds = [
-            'Symfony\Component\Form\Type\FormType' => [
+            FormType::class => [
                 'symfony.form.type.form_extension',
             ],
         ];
         $guesserServiceIds = [];
         $mappingTypes = [
-            'form' => 'Symfony\Component\Form\Type\FormType',
+            'form' => FormType::class,
         ];
         $extensionTypes = [
             'form' => [
@@ -80,6 +84,6 @@ class DependencyInjectionExtensionTest extends TestCase
 
         $f = new DependencyInjectionExtension($container, $typeServiceIds, $typeExtensionServiceIds, $guesserServiceIds, $mappingTypes, $extensionTypes);
 
-        $this->assertCount(2, $f->getTypeExtensions('Symfony\Component\Form\Type\FormType'));
+        $this->assertCount(2, $f->getTypeExtensions(FormType::class));
     }
 }

--- a/tests/Form/FormHelperTest.php
+++ b/tests/Form/FormHelperTest.php
@@ -13,22 +13,24 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Form\FormHelper;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigInterface;
 
 class FormHelperTest extends TestCase
 {
     public function testRemoveFields()
     {
-        $dataMapper = $this->createMock('Symfony\Component\Form\DataMapperInterface');
+        $dataMapper = $this->createMock(DataMapperInterface::class);
 
-        $config = $this->createMock('Symfony\Component\Form\FormConfigInterface');
+        $config = $this->createMock(FormConfigInterface::class);
         $config->expects($this->any())->method('getName')->will($this->returnValue('root'));
         $config->expects($this->any())->method('getCompound')->will($this->returnValue(true));
         $config->expects($this->any())->method('getDataMapper')->will($this->returnValue($dataMapper));
 
         $form = new Form($config);
 
-        $config = $this->createMock('Symfony\Component\Form\FormConfigInterface');
+        $config = $this->createMock(FormConfigInterface::class);
         $config->expects($this->any())->method('getName')->will($this->returnValue('child'));
 
         $form->add(new Form($config));

--- a/tests/Form/Type/BasePickerTypeTest.php
+++ b/tests/Form/Type/BasePickerTypeTest.php
@@ -16,7 +16,9 @@ use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\BasePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class BasePickerTest extends BasePickerType
 {
@@ -40,11 +42,11 @@ class BasePickerTypeTest extends TestCase
     {
         $type = new BasePickerTest(
             new MomentFormatConverter(),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(TranslatorInterface::class)
         );
 
         $view = new FormView();
-        $form = new Form($this->createMock('Symfony\Component\Form\FormConfigInterface'));
+        $form = new Form($this->createMock(FormConfigInterface::class));
 
         $type->finishView($view, $form, ['format' => 'yyyy-MM-dd']);
 

--- a/tests/Form/Type/BooleanTypeTest.php
+++ b/tests/Form/Type/BooleanTypeTest.php
@@ -14,7 +14,9 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\Form\Test\FormBuilderInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -23,7 +25,7 @@ class BooleanTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -83,7 +85,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock(FormBuilderInterface::class);
         $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, $optionResolver->resolve([
@@ -100,7 +102,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock(FormBuilderInterface::class);
         $builder->expects($this->never())->method('addModelTransformer');
 
         $type->buildForm($builder, $optionResolver->resolve([]));
@@ -112,7 +114,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock(FormBuilderInterface::class);
         $builder->expects($this->never())->method('addModelTransformer');
 
         $resolvedOptions = $optionResolver->resolve([
@@ -147,7 +149,7 @@ class BooleanTypeTest extends TypeTestCase
 
         FormHelper::configureOptions($type, $optionResolver = new OptionsResolver());
 
-        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock(FormBuilderInterface::class);
         $builder->expects($this->never())->method('addModelTransformer');
 
         $resolvedOptions = $optionResolver->resolve([

--- a/tests/Form/Type/CollectionTypeTest.php
+++ b/tests/Form/Type/CollectionTypeTest.php
@@ -14,6 +14,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -21,7 +22,7 @@ class CollectionTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Form/Type/ColorSelectorTypeTest.php
+++ b/tests/Form/Type/ColorSelectorTypeTest.php
@@ -15,6 +15,7 @@ use Sonata\CoreBundle\Color\Colors;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ColorSelectorType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,7 +26,7 @@ class ColorSelectorTypeTest extends TypeTestCase
      */
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Form/Type/ColorTypeTest.php
+++ b/tests/Form/Type/ColorTypeTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\Type\ColorType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class ColorTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Form/Type/DatePickerTypeTest.php
+++ b/tests/Form/Type/DatePickerTypeTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DatePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -23,7 +25,7 @@ class DatePickerTypeTest extends TestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -34,8 +36,8 @@ class DatePickerTypeTest extends TestCase
             }));
 
         $type = new DatePickerType(
-            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(MomentFormatConverter::class),
+            $this->createMock(TranslatorInterface::class)
         );
         $type->buildForm($formBuilder, [
             'dp_pick_time' => false,
@@ -46,8 +48,8 @@ class DatePickerTypeTest extends TestCase
     public function testGetParent()
     {
         $form = new DatePickerType(
-            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(MomentFormatConverter::class),
+            $this->createMock(TranslatorInterface::class)
         );
 
         $parentRef = $form->getParent();
@@ -57,7 +59,7 @@ class DatePickerTypeTest extends TestCase
 
     public function testGetName()
     {
-        $type = new DatePickerType(new MomentFormatConverter(), $this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DatePickerType(new MomentFormatConverter(), $this->createMock(TranslatorInterface::class));
 
         $this->assertSame('sonata_type_date_picker', $type->getName());
     }

--- a/tests/Form/Type/DateRangePickerTypeTest.php
+++ b/tests/Form/Type/DateRangePickerTypeTest.php
@@ -14,14 +14,16 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DatePickerType;
 use Sonata\CoreBundle\Form\Type\DateRangePickerType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class DateRangePickerTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -31,7 +33,7 @@ class DateRangePickerTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangePickerType($this->createMock(TranslatorInterface::class));
         $type->buildForm($formBuilder, [
             'field_options' => [],
             'field_options_start' => [],
@@ -42,7 +44,7 @@ class DateRangePickerTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateRangePickerType($this->createMock(TranslatorInterface::class));
 
         $parentRef = $form->getParent();
 
@@ -51,7 +53,7 @@ class DateRangePickerTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangePickerType($this->createMock(TranslatorInterface::class));
 
         $this->assertSame('sonata_type_date_range_picker', $type->getName());
 

--- a/tests/Form/Type/DateRangeTypeTest.php
+++ b/tests/Form/Type/DateRangeTypeTest.php
@@ -14,14 +14,16 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DateRangeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class DateRangeTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -31,7 +33,7 @@ class DateRangeTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangeType($this->createMock(TranslatorInterface::class));
         $type->buildForm($formBuilder, [
             'field_options' => [],
             'field_options_start' => [],
@@ -42,7 +44,7 @@ class DateRangeTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateRangeType($this->createMock(TranslatorInterface::class));
 
         $parentRef = $form->getParent();
 
@@ -51,7 +53,7 @@ class DateRangeTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateRangeType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateRangeType($this->createMock(TranslatorInterface::class));
 
         $this->assertSame('sonata_type_date_range', $type->getName());
 

--- a/tests/Form/Type/DateTimePickerTypeTest.php
+++ b/tests/Form/Type/DateTimePickerTypeTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DateTimePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -23,7 +25,7 @@ class DateTimePickerTypeTest extends TestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -34,8 +36,8 @@ class DateTimePickerTypeTest extends TestCase
             }));
 
         $type = new DateTimePickerType(
-            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(MomentFormatConverter::class),
+            $this->createMock(TranslatorInterface::class)
         );
 
         $type->buildForm($formBuilder, [
@@ -50,8 +52,8 @@ class DateTimePickerTypeTest extends TestCase
     public function testGetParent()
     {
         $form = new DateTimePickerType(
-            $this->createMock('Sonata\CoreBundle\Date\MomentFormatConverter'),
-            $this->createMock('Symfony\Component\Translation\TranslatorInterface')
+            $this->createMock(MomentFormatConverter::class),
+            $this->createMock(TranslatorInterface::class)
         );
 
         $parentRef = $form->getParent();
@@ -61,7 +63,7 @@ class DateTimePickerTypeTest extends TestCase
 
     public function testGetName()
     {
-        $type = new DateTimePickerType(new MomentFormatConverter(), $this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimePickerType(new MomentFormatConverter(), $this->createMock(TranslatorInterface::class));
 
         $this->assertSame('sonata_type_datetime_picker', $type->getName());
     }

--- a/tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -14,14 +14,16 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\DateTimePickerType;
 use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class DateTimeRangePickerTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -31,7 +33,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimeRangePickerType($this->createMock(TranslatorInterface::class));
         $type->buildForm($formBuilder, [
             'field_options' => [],
             'field_options_start' => [],
@@ -42,7 +44,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new DateTimeRangePickerType($this->createMock(TranslatorInterface::class));
 
         $parentRef = $form->getParent();
 
@@ -51,7 +53,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $type = new DateTimeRangePickerType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new DateTimeRangePickerType($this->createMock(TranslatorInterface::class));
 
         $this->assertSame('sonata_type_datetime_range_picker', $type->getName());
 

--- a/tests/Form/Type/DoctrineORMSerializationTypeTest.php
+++ b/tests/Form/Type/DoctrineORMSerializationTypeTest.php
@@ -11,10 +11,15 @@
 
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo as DoctrineMetadata;
 use JMS\Serializer\Metadata\ClassMetadata as SerializerMetadata;
 use JMS\Serializer\Metadata\PropertyMetadata;
+use Metadata\MetadataFactoryInterface;
 use Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
@@ -43,13 +48,13 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
      */
     public function setUp()
     {
-        if (!interface_exists('\Metadata\MetadataFactoryInterface') or !interface_exists('\Doctrine\ORM\EntityManagerInterface')) {
+        if (!interface_exists(MetadataFactoryInterface::class) or !interface_exists(EntityManagerInterface::class)) {
             $this->markTestSkipped('Serializer and Doctrine has to be loaded to run this test');
         }
 
         parent::setUp();
 
-        $this->class = 'Sonata\CoreBundle\Tests\Form\Type\FakeMetadataClass';
+        $this->class = FakeMetadataClass::class;
     }
 
     /**
@@ -64,7 +69,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
         } else {
             $this->factory = $this->createCustomFactory($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
-            $type = 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType';
+            $type = DoctrineORMSerializationType::class;
         }
 
         $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
@@ -73,9 +78,9 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
         $this->assertSame(3, $form->count(), 'Should return 3 items in form');
 
         // Assets that forms are correctly returned for correct fields
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('name'), 'Should return a form instance');
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('url'), 'Should return a form instance');
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('comments'), 'Should return a form instance');
+        $this->assertInstanceOf(FormInterface::class, $form->get('name'), 'Should return a form instance');
+        $this->assertInstanceOf(FormInterface::class, $form->get('url'), 'Should return a form instance');
+        $this->assertInstanceOf(FormInterface::class, $form->get('comments'), 'Should return a form instance');
 
         // Asserts that required fields / associations rules are correctly parsed
         $this->assertFalse($form->get('name')->isRequired(), 'Should return a non-required field');
@@ -85,7 +90,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
 
     public function testBuildFormAddCall()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -96,7 +101,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             }));
 
         $type = new DoctrineORMSerializationType(
-            $this->getMetadataFactoryMock(), // $this->createMock('Metadata\MetadataFactoryInterface'),
+            $this->getMetadataFactoryMock(), // $this->createMock(MetadataFactoryInterface::class),
             $this->getRegistryMock(),
             'form_type_test',
             $this->class,
@@ -118,7 +123,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
         } else {
             $this->factory = $this->createCustomFactory($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_write');
-            $type = 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType';
+            $type = DoctrineORMSerializationType::class;
         }
 
         $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
@@ -127,8 +132,8 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
         $this->assertSame(2, $form->count(), 'Should return 2 elements in the form');
 
         // Assets that forms are correctly returned for correct fields
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('url'), 'Should return a form instance');
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $form->get('comments'), 'Should return a form instance');
+        $this->assertInstanceOf(FormInterface::class, $form->get('url'), 'Should return a form instance');
+        $this->assertInstanceOf(FormInterface::class, $form->get('comments'), 'Should return a form instance');
     }
 
     /**
@@ -143,7 +148,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             $type = new DoctrineORMSerializationType($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_invalid');
         } else {
             $this->factory = $this->createCustomFactory($metadataFactory, $registry, 'form_type_test', $this->class, 'serialization_api_invalid');
-            $type = 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType';
+            $type = DoctrineORMSerializationType::class;
         }
 
         $form = $this->factory->createBuilder($type, null)->setCompound(true)->getForm();
@@ -155,8 +160,8 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
     public function testGetParent()
     {
         $form = new DoctrineORMSerializationType(
-            $this->createMock('Metadata\MetadataFactoryInterface'),
-            $this->createMock('Doctrine\Common\Persistence\ManagerRegistry'),
+            $this->createMock(MetadataFactoryInterface::class),
+            $this->createMock(ManagerRegistry::class),
             'form_type_test',
             $this->class,
             'serialization_api_write'
@@ -188,7 +193,7 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
         $classMetadata->addPropertyMetadata($url);
         $classMetadata->addPropertyMetadata($comments);
 
-        $metadataFactory = $this->createMock('Metadata\MetadataFactoryInterface');
+        $metadataFactory = $this->createMock(MetadataFactoryInterface::class);
         $metadataFactory->expects($this->once())->method('getMetadataForClass')->will($this->returnValue($classMetadata));
 
         return $metadataFactory;
@@ -219,10 +224,10 @@ class DoctrineORMSerializationTypeTest extends TypeTestCase
             ],
         ];
 
-        $entityManager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
+        $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects($this->once())->method('getClassMetadata')->will($this->returnValue($classMetadata));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($entityManager));
 
         return $registry;

--- a/tests/Form/Type/EqualTypeTest.php
+++ b/tests/Form/Type/EqualTypeTest.php
@@ -14,15 +14,17 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class EqualTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -32,7 +34,7 @@ class EqualTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new EqualType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new EqualType($this->createMock(TranslatorInterface::class));
         $type->buildForm($formBuilder, [
             'choices' => [],
         ]);
@@ -40,7 +42,7 @@ class EqualTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new EqualType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new EqualType($this->createMock(TranslatorInterface::class));
 
         $parentRef = $form->getParent();
 
@@ -49,7 +51,7 @@ class EqualTypeTest extends TypeTestCase
 
     public function testGetDefaultOptions()
     {
-        $mock = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $mock = $this->createMock(TranslatorInterface::class);
 
         $mock->expects($this->exactly(0))
             ->method('trans')

--- a/tests/Form/Type/ImmutableArrayTypeTest.php
+++ b/tests/Form/Type/ImmutableArrayTypeTest.php
@@ -13,16 +13,21 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Test\FormBuilderInterface as TestFormBuilderInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImmutableArrayTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -53,7 +58,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
 
         $this->assertSame('sonata_type_immutable_array', $type->getName());
 
-        $this->assertSame(version_compare(Kernel::VERSION, '2.8', '<') ? 'form' : 'Symfony\Component\Form\Extension\Core\Type\FormType', $type->getParent());
+        $this->assertSame(version_compare(Kernel::VERSION, '2.8', '<') ? 'form' : FormType::class, $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 
@@ -70,7 +75,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
     {
         $type = new ImmutableArrayType();
 
-        $builder = $this->createMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder = $this->createMock(TestFormBuilderInterface::class);
         $builder->expects($this->once())->method('add')->with(
             $this->callback(function ($name) {
                 return 'ttl' === $name;
@@ -88,7 +93,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
             $self->assertEquals(['foo', 'bar'], $extra);
             $self->assertEquals($name, 'ttl');
             $self->assertEquals($type, TextType::class);
-            $self->assertInstanceOf('Symfony\Component\Form\Test\FormBuilderInterface', $builder);
+            $self->assertInstanceOf(TestFormBuilderInterface::class, $builder);
 
             return ['1' => '1'];
         };
@@ -109,9 +114,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
         $type = new ImmutableArrayType();
         $type->configureOptions($optionsResolver);
 
-        $this->expectException(
-            'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException'
-        );
+        $this->expectException(InvalidOptionsException::class);
         $this->expectExceptionMessage(
             'The option "keys" with value array is invalid.'
         );
@@ -129,7 +132,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
         $this->assertArrayHasKey(
             'keys',
             $optionsResolver->resolve(['keys' => [$this->getMockBuilder(
-                'Symfony\Component\Form\FormBuilderInterface'
+                FormBuilderInterface::class
             )->getMock()]])
         );
     }

--- a/tests/Form/Type/StatusTypeTest.php
+++ b/tests/Form/Type/StatusTypeTest.php
@@ -14,6 +14,7 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\BaseStatusType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -35,7 +36,7 @@ class StatusTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -45,7 +46,7 @@ class StatusTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
+        $type = new StatusType(Choice::class, 'getList', 'choice_type');
         $type->buildForm($formBuilder, [
             'choices' => [],
         ]);
@@ -53,7 +54,7 @@ class StatusTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
+        $form = new StatusType(Choice::class, 'getList', 'choice_type');
 
         $parentRef = $form->getParent();
 
@@ -66,7 +67,7 @@ class StatusTypeTest extends TypeTestCase
             1 => 'salut',
         ];
 
-        $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type');
+        $type = new StatusType(Choice::class, 'getList', 'choice_type');
 
         $this->assertSame('choice_type', $type->getName());
 
@@ -87,7 +88,7 @@ class StatusTypeTest extends TypeTestCase
             2 => 'toi!',
         ];
 
-        $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type', true);
+        $type = new StatusType(Choice::class, 'getList', 'choice_type', true);
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(ChoiceType::class, $type->getParent());
@@ -109,7 +110,7 @@ class StatusTypeTest extends TypeTestCase
             2 => 'error',
         ];
 
-        $type = new StatusType('Sonata\CoreBundle\Tests\Form\Type\Choice', 'getList', 'choice_type', true);
+        $type = new StatusType(Choice::class, 'getList', 'choice_type', true);
 
         $this->assertSame('choice_type', $type->getName());
         $this->assertSame(ChoiceType::class, $type->getParent());

--- a/tests/Form/Type/TranslatableChoiceTypeTest.php
+++ b/tests/Form/Type/TranslatableChoiceTypeTest.php
@@ -14,8 +14,10 @@ namespace Sonata\CoreBundle\Tests\Form\Type;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @group legacy
@@ -24,7 +26,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
-        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
             ->method('add')
@@ -34,7 +36,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
                 }
             }));
 
-        $type = new TranslatableChoiceType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $type = new TranslatableChoiceType($this->createMock(TranslatorInterface::class));
         $type->buildForm($formBuilder, [
             'catalogue' => 'messages',
         ]);
@@ -42,7 +44,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        $form = new TranslatableChoiceType($this->createMock('Symfony\Component\Translation\TranslatorInterface'));
+        $form = new TranslatableChoiceType($this->createMock(TranslatorInterface::class));
 
         $parentRef = $form->getParent();
 
@@ -51,7 +53,7 @@ class TranslatableChoiceTypeTest extends TypeTestCase
 
     public function testLegacyGetDefaultOptions()
     {
-        $stub = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $stub = $this->createMock(TranslatorInterface::class);
 
         $type = new TranslatableChoiceType($stub);
 

--- a/tests/Model/Adapter/AdapterChainTest.php
+++ b/tests/Model/Adapter/AdapterChainTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\Adapter\AdapterChain;
+use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 
 class AdapterChainTest extends TestCase
 {
@@ -28,10 +29,10 @@ class AdapterChainTest extends TestCase
     {
         $adapter = new AdapterChain();
 
-        $adapter->addAdapter($fake1 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake1 = $this->createMock(AdapterInterface::class));
         $fake1->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue(null));
 
-        $adapter->addAdapter($fake2 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake2 = $this->createMock(AdapterInterface::class));
 
         $fake2->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue('voila'));
 
@@ -42,10 +43,10 @@ class AdapterChainTest extends TestCase
     {
         $adapter = new AdapterChain();
 
-        $adapter->addAdapter($fake1 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake1 = $this->createMock(AdapterInterface::class));
         $fake1->expects($this->once())->method('getNormalizedIdentifier')->will($this->returnValue(null));
 
-        $adapter->addAdapter($fake2 = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface'));
+        $adapter->addAdapter($fake2 = $this->createMock(AdapterInterface::class));
 
         $fake2->expects($this->once())->method('getNormalizedIdentifier')->will($this->returnValue('voila'));
 

--- a/tests/Model/Adapter/DoctrineORMAdapterTest.php
+++ b/tests/Model/Adapter/DoctrineORMAdapterTest.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\Adapter\DoctrineORMAdapter;
 
@@ -18,7 +21,7 @@ class DoctrineORMAdapterTest extends TestCase
 {
     public function setUp()
     {
-        if (!class_exists('Doctrine\ORM\UnitOfWork')) {
+        if (!class_exists(UnitOfWork::class)) {
             $this->markTestSkipped('Doctrine ORM not installed');
         }
     }
@@ -27,7 +30,7 @@ class DoctrineORMAdapterTest extends TestCase
     {
         $this->expectException(\RunTimeException::class);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrineORMAdapter($registry);
 
         $adapter->getNormalizedIdentifier(1);
@@ -35,7 +38,7 @@ class DoctrineORMAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNull()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrineORMAdapter($registry);
 
         $this->assertNull($adapter->getNormalizedIdentifier(null));
@@ -43,7 +46,7 @@ class DoctrineORMAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNoManager()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $adapter = new DoctrineORMAdapter($registry);
@@ -53,13 +56,13 @@ class DoctrineORMAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNotManaged()
     {
-        $unitOfWork = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')->disableOriginalConstructor()->getMock();
+        $unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
         $unitOfWork->expects($this->once())->method('isInIdentityMap')->will($this->returnValue(false));
 
-        $manager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->createMock(EntityManagerInterface::class);
         $manager->expects($this->any())->method('getUnitOfWork')->will($this->returnValue($unitOfWork));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrineORMAdapter($registry);
@@ -72,14 +75,14 @@ class DoctrineORMAdapterTest extends TestCase
      */
     public function testNormalizedIdentifierWithValidObject($data, $expected)
     {
-        $unitOfWork = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')->disableOriginalConstructor()->getMock();
+        $unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
         $unitOfWork->expects($this->once())->method('isInIdentityMap')->will($this->returnValue(true));
         $unitOfWork->expects($this->once())->method('getEntityIdentifier')->will($this->returnValue($data));
 
-        $manager = $this->createMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->createMock(EntityManagerInterface::class);
         $manager->expects($this->any())->method('getUnitOfWork')->will($this->returnValue($unitOfWork));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrineORMAdapter($registry);

--- a/tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
+++ b/tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
@@ -11,7 +11,10 @@
 
 namespace Sonata\CoreBundle\Tests\Model\Adapter;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\Adapter\DoctrinePHPCRAdapter;
 
@@ -24,7 +27,7 @@ class DoctrinePHPCRAdapterTest extends TestCase
 {
     public function setUp()
     {
-        if (!class_exists('Doctrine\ODM\PHPCR\UnitOfWork')) {
+        if (!class_exists(UnitOfWork::class)) {
             $this->markTestSkipped('Doctrine PHPCR not installed');
         }
     }
@@ -33,7 +36,7 @@ class DoctrinePHPCRAdapterTest extends TestCase
     {
         $this->expectException(\RunTimeException::class);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrinePHPCRAdapter($registry);
 
         $adapter->getNormalizedIdentifier(1);
@@ -41,7 +44,7 @@ class DoctrinePHPCRAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNull()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $adapter = new DoctrinePHPCRAdapter($registry);
 
         $this->assertNull($adapter->getNormalizedIdentifier(null));
@@ -49,7 +52,7 @@ class DoctrinePHPCRAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNoManager()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $adapter = new DoctrinePHPCRAdapter($registry);
@@ -59,10 +62,10 @@ class DoctrinePHPCRAdapterTest extends TestCase
 
     public function testNormalizedIdentifierWithNotManaged()
     {
-        $manager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $manager = $this->getMockBuilder(DocumentManager::class)->disableOriginalConstructor()->getMock();
         $manager->expects($this->once())->method('contains')->will($this->returnValue(false));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrinePHPCRAdapter($registry);
@@ -75,15 +78,15 @@ class DoctrinePHPCRAdapterTest extends TestCase
      */
     public function testNormalizedIdentifierWithValidObject($data, $expected)
     {
-        $metadata = new ClassMetadata('Sonata\CoreBundle\Tests\Model\Adapter\MyDocument');
+        $metadata = new ClassMetadata(MyDocument::class);
         $metadata->identifier = 'path';
-        $metadata->reflFields['path'] = new \ReflectionProperty('Sonata\CoreBundle\Tests\Model\Adapter\MyDocument', 'path');
+        $metadata->reflFields['path'] = new \ReflectionProperty(MyDocument::class, 'path');
 
-        $manager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
+        $manager = $this->getMockBuilder(DocumentManager::class)->disableOriginalConstructor()->getMock();
         $manager->expects($this->any())->method('contains')->will($this->returnValue(true));
         $manager->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($manager));
 
         $adapter = new DoctrinePHPCRAdapter($registry);

--- a/tests/Model/BaseDocumentManagerTest.php
+++ b/tests/Model/BaseDocumentManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\BaseDocumentManager;
 
@@ -22,7 +23,7 @@ class BaseDocumentManagerTest extends TestCase
 {
     public function getManager()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
         $manager = new DocumentManager('classname', $registry);
 

--- a/tests/Model/BaseEntityManagerTest.php
+++ b/tests/Model/BaseEntityManagerTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\CoreBundle\Tests\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\BaseEntityManager;
 
@@ -22,7 +24,7 @@ class BaseEntityManagerTest extends TestCase
 {
     public function getManager()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
         $manager = new EntityManager('classname', $registry);
 
@@ -47,7 +49,7 @@ class BaseEntityManagerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to find the mapping information for the class classname. Please check the `auto_mapping` option (http://symfony.com/doc/current/reference/configuration/doctrine.html#configuration-overview) or add the bundle to the `mappings` section in the doctrine configuration');
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue(null));
 
         $manager = new EntityManager('classname', $registry);
@@ -56,9 +58,9 @@ class BaseEntityManagerTest extends TestCase
 
     public function testGetEntityManager()
     {
-        $objectManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock(ObjectManager::class);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->once())->method('getManagerForClass')->will($this->returnValue($objectManager));
 
         $manager = new EntityManager('classname', $registry);

--- a/tests/Model/BaseManagerTest.php
+++ b/tests/Model/BaseManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\Tests\Model;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Model\BaseManager;
@@ -45,7 +46,7 @@ class BaseManagerTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Object must be instance of class, DateTime given');
 
-        $manager = new ManagerTest('class', $this->createMock('Doctrine\Common\Persistence\ManagerRegistry'));
+        $manager = new ManagerTest('class', $this->createMock(ManagerRegistry::class));
 
         $manager->publicCheckObject(new \DateTime());
     }

--- a/tests/Serializer/BaseSerializerHandlerTest.php
+++ b/tests/Serializer/BaseSerializerHandlerTest.php
@@ -11,8 +11,11 @@
 
 namespace Sonata\CoreBundle\Tests\Serializer;
 
+use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\VisitorInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer;
 
 /**
@@ -27,7 +30,7 @@ final class BaseSerializerHandlerTest extends TestCase
      */
     public function testGetSubscribingMethodsWithDefaultFormats()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
 
         $serializer = new FooSerializer($manager);
 
@@ -77,7 +80,7 @@ final class BaseSerializerHandlerTest extends TestCase
 
     public function testSetFormats()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
 
         $serializer = new FooSerializer($manager);
 
@@ -105,7 +108,7 @@ final class BaseSerializerHandlerTest extends TestCase
 
     public function testAddFormats()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
 
         $serializer = new FooSerializer($manager);
 
@@ -147,7 +150,7 @@ final class BaseSerializerHandlerTest extends TestCase
 
     public function testSerializeObjectToIdWithDataIsInstanceOfManager()
     {
-        $modelInstance = $this->getMockBuilder('Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer')
+        $modelInstance = $this->getMockBuilder(FooSerializer::class)
             ->disableOriginalConstructor()
             ->setMethods(['getId'])
             ->getMock();
@@ -156,14 +159,14 @@ final class BaseSerializerHandlerTest extends TestCase
             ->method('getId')
             ->willReturn(1);
 
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
         $manager->expects($this->once())
             ->method('getClass')
             ->willReturn(get_class($modelInstance));
 
-        $context = $this->createMock('JMS\Serializer\Context');
+        $context = $this->createMock(Context::class);
 
-        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock(VisitorInterface::class);
         $visitor->expects($this->once())
             ->method('visitInteger')
             ->with(1, ['foo'], $context)
@@ -176,18 +179,18 @@ final class BaseSerializerHandlerTest extends TestCase
 
     public function testSerializeObjectToIdWithDataIsNotInstanceOfManager()
     {
-        $modelInstance = $this->getMockBuilder('Sonata\CoreBundle\Tests\Fixtures\Bundle\Serializer\FooSerializer')
+        $modelInstance = $this->getMockBuilder(FooSerializer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
         $manager->expects($this->once())
             ->method('getClass')
             ->willReturn('bar');
 
-        $context = $this->createMock('JMS\Serializer\Context');
+        $context = $this->createMock(Context::class);
 
-        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock(VisitorInterface::class);
         $visitor->expects($this->never())
             ->method('visitInteger');
 
@@ -198,13 +201,13 @@ final class BaseSerializerHandlerTest extends TestCase
 
     public function testDeserializeObjectFromId()
     {
-        $manager = $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        $manager = $this->createMock(ManagerInterface::class);
         $manager->expects($this->once())
             ->method('findOneBy')
             ->with(['id' => 'foo'])
             ->willReturn('bar');
 
-        $visitor = $this->createMock('JMS\Serializer\VisitorInterface');
+        $visitor = $this->createMock(VisitorInterface::class);
 
         $serializer = new FooSerializer($manager);
 

--- a/tests/SonataCoreBundleTest.php
+++ b/tests/SonataCoreBundleTest.php
@@ -16,8 +16,54 @@ use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
+use Sonata\CoreBundle\Form\Type\ColorSelectorType;
+use Sonata\CoreBundle\Form\Type\ColorType;
+use Sonata\CoreBundle\Form\Type\DatePickerType;
+use Sonata\CoreBundle\Form\Type\DateRangePickerType;
+use Sonata\CoreBundle\Form\Type\DateRangeType;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType;
+use Sonata\CoreBundle\Form\Type\EqualType;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
 use Sonata\CoreBundle\SonataCoreBundle;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\ResetType;
+use Symfony\Component\Form\Extension\Core\Type\SearchType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
@@ -26,7 +72,7 @@ final class SonataCoreBundleTest extends TestCase
 {
     public function testBuild()
     {
-        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['addCompilerPass'])
             ->getMock();
 
@@ -57,7 +103,7 @@ final class SonataCoreBundleTest extends TestCase
         $bundle = new SonataCoreBundle();
         $bundle->build($containerBuilder);
 
-        $this->assertMappingTypeRegistered('form', 'Symfony\Component\Form\Extension\Core\Type\FormType');
+        $this->assertMappingTypeRegistered('form', FormType::class);
     }
 
     public function testBootCallsRegisterFormMapping()
@@ -65,7 +111,7 @@ final class SonataCoreBundleTest extends TestCase
         $bundle = new SonataCoreBundle();
         $bundle->boot();
 
-        $this->assertMappingTypeRegistered('form', 'Symfony\Component\Form\Extension\Core\Type\FormType');
+        $this->assertMappingTypeRegistered('form', FormType::class);
     }
 
     /**
@@ -85,50 +131,50 @@ final class SonataCoreBundleTest extends TestCase
     public function getRegisteredFormMappingAndTypes()
     {
         return [
-            ['form', 'Symfony\Component\Form\Extension\Core\Type\FormType'],
-            ['birthday', 'Symfony\Component\Form\Extension\Core\Type\BirthdayType'],
-            ['checkbox', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'],
-            ['choice', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'],
-            ['collection', 'Symfony\Component\Form\Extension\Core\Type\CollectionType'],
-            ['country', 'Symfony\Component\Form\Extension\Core\Type\CountryType'],
-            ['date', 'Symfony\Component\Form\Extension\Core\Type\DateType'],
-            ['datetime', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'],
-            ['email', 'Symfony\Component\Form\Extension\Core\Type\EmailType'],
-            ['file', 'Symfony\Component\Form\Extension\Core\Type\FileType'],
-            ['hidden', 'Symfony\Component\Form\Extension\Core\Type\HiddenType'],
-            ['integer', 'Symfony\Component\Form\Extension\Core\Type\IntegerType'],
-            ['language', 'Symfony\Component\Form\Extension\Core\Type\LanguageType'],
-            ['locale', 'Symfony\Component\Form\Extension\Core\Type\LocaleType'],
-            ['money', 'Symfony\Component\Form\Extension\Core\Type\MoneyType'],
-            ['number', 'Symfony\Component\Form\Extension\Core\Type\NumberType'],
-            ['password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType'],
-            ['percent', 'Symfony\Component\Form\Extension\Core\Type\PercentType'],
-            ['radio', 'Symfony\Component\Form\Extension\Core\Type\RadioType'],
-            ['repeated', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType'],
-            ['search', 'Symfony\Component\Form\Extension\Core\Type\SearchType'],
-            ['textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType'],
-            ['text', 'Symfony\Component\Form\Extension\Core\Type\TextType'],
-            ['time', 'Symfony\Component\Form\Extension\Core\Type\TimeType'],
-            ['timezone', 'Symfony\Component\Form\Extension\Core\Type\TimezoneType'],
-            ['url', 'Symfony\Component\Form\Extension\Core\Type\UrlType'],
-            ['button', 'Symfony\Component\Form\Extension\Core\Type\ButtonType'],
-            ['submit', 'Symfony\Component\Form\Extension\Core\Type\SubmitType'],
-            ['reset', 'Symfony\Component\Form\Extension\Core\Type\ResetType'],
-            ['currency', 'Symfony\Component\Form\Extension\Core\Type\CurrencyType'],
-            ['entity', 'Symfony\Bridge\Doctrine\Form\Type\EntityType'],
-            ['sonata_type_immutable_array', 'Sonata\CoreBundle\Form\Type\ImmutableArrayType'],
-            ['sonata_type_boolean', 'Sonata\CoreBundle\Form\Type\BooleanType'],
-            ['sonata_type_collection', 'Sonata\CoreBundle\Form\Type\CollectionType'],
-            ['sonata_type_translatable_choice', 'Sonata\CoreBundle\Form\Type\TranslatableChoiceType'],
-            ['sonata_type_date_range', 'Sonata\CoreBundle\Form\Type\DateRangeType'],
-            ['sonata_type_datetime_range', 'Sonata\CoreBundle\Form\Type\DateTimeRangeType'],
-            ['sonata_type_date_picker', 'Sonata\CoreBundle\Form\Type\DatePickerType'],
-            ['sonata_type_datetime_picker', 'Sonata\CoreBundle\Form\Type\DateTimePickerType'],
-            ['sonata_type_date_range_picker', 'Sonata\CoreBundle\Form\Type\DateRangePickerType'],
-            ['sonata_type_datetime_range_picker', 'Sonata\CoreBundle\Form\Type\DateTimeRangePickerType'],
-            ['sonata_type_equal', 'Sonata\CoreBundle\Form\Type\EqualType'],
-            ['sonata_type_color', 'Sonata\CoreBundle\Form\Type\ColorType'],
-            ['sonata_type_color_selector', 'Sonata\CoreBundle\Form\Type\ColorSelectorType'],
+            ['form', FormType::class],
+            ['birthday', BirthdayType::class],
+            ['checkbox', CheckboxType::class],
+            ['choice', ChoiceType::class],
+            ['collection', SymfonyCollectionType::class],
+            ['country', CountryType::class],
+            ['date', DateType::class],
+            ['datetime', DateTimeType::class],
+            ['email', EmailType::class],
+            ['file', FileType::class],
+            ['hidden', HiddenType::class],
+            ['integer', IntegerType::class],
+            ['language', LanguageType::class],
+            ['locale', LocaleType::class],
+            ['money', MoneyType::class],
+            ['number', NumberType::class],
+            ['password', PasswordType::class],
+            ['percent', PercentType::class],
+            ['radio', RadioType::class],
+            ['repeated', RepeatedType::class],
+            ['search', SearchType::class],
+            ['textarea', TextareaType::class],
+            ['text', TextType::class],
+            ['time', TimeType::class],
+            ['timezone', TimezoneType::class],
+            ['url', UrlType::class],
+            ['button', ButtonType::class],
+            ['submit', SubmitType::class],
+            ['reset', ResetType::class],
+            ['currency', CurrencyType::class],
+            ['entity', EntityType::class],
+            ['sonata_type_immutable_array', ImmutableArrayType::class],
+            ['sonata_type_boolean', BooleanType::class],
+            ['sonata_type_collection', CollectionType::class],
+            ['sonata_type_translatable_choice', TranslatableChoiceType::class],
+            ['sonata_type_date_range', DateRangeType::class],
+            ['sonata_type_datetime_range', DateTimeRangeType::class],
+            ['sonata_type_date_picker', DatePickerType::class],
+            ['sonata_type_datetime_picker', DateTimePickerType::class],
+            ['sonata_type_date_range_picker', DateRangePickerType::class],
+            ['sonata_type_datetime_range_picker', DateTimeRangePickerType::class],
+            ['sonata_type_equal', EqualType::class],
+            ['sonata_type_color', ColorType::class],
+            ['sonata_type_color_selector', ColorSelectorType::class],
         ];
     }
 
@@ -163,7 +209,7 @@ final class SonataCoreBundleTest extends TestCase
     {
         $bundle = new SonataCoreBundle();
 
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $container->expects($this->once())
             ->method('hasParameter')
@@ -179,7 +225,7 @@ final class SonataCoreBundleTest extends TestCase
             ->with('sonata.core.form.mapping.extension')
             ->willReturn(['fooMapping' => ['barExtension']]);
 
-        $reflectedBundle = new \ReflectionClass('Sonata\CoreBundle\SonataCoreBundle');
+        $reflectedBundle = new \ReflectionClass(SonataCoreBundle::class);
         $reflectedContainer = $reflectedBundle->getProperty('container');
         $reflectedContainer->setAccessible(true);
         $reflectedContainer->setValue($bundle, $container);

--- a/tests/Twig/Extension/StatusExtensionTest.php
+++ b/tests/Twig/Extension/StatusExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
 use Sonata\CoreBundle\Twig\Extension\StatusExtension;
 
 class StatusExtensionTest extends TestCase
@@ -33,7 +34,7 @@ class StatusExtensionTest extends TestCase
     public function testStatusClassDefaultValue()
     {
         $extension = new StatusExtension();
-        $statusService = $this->getMockBuilder('Sonata\CoreBundle\Component\Status\StatusClassRendererInterface')
+        $statusService = $this->getMockBuilder(StatusClassRendererInterface::class)
             ->getMock();
         $statusService->expects($this->once())
             ->method('handlesObject')

--- a/tests/Twig/Extension/TemplateExtensionTest.php
+++ b/tests/Twig/Extension/TemplateExtensionTest.php
@@ -12,7 +12,9 @@
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 use Sonata\CoreBundle\Twig\Extension\TemplateExtension;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateExtensionTest extends TestCase
 {
@@ -24,9 +26,9 @@ class TemplateExtensionTest extends TestCase
         setlocale(LC_ALL, 'en_US.utf8');
         setlocale(LC_CTYPE, 'en_US.utf8');
 
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
 
-        $adapter = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->never())->method('getUrlsafeIdentifier');
 
         $extension = new TemplateExtension(true, $translator, $adapter);
@@ -41,9 +43,9 @@ class TemplateExtensionTest extends TestCase
 
     public function testSafeUrl()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
 
-        $adapter = $this->createMock('Sonata\CoreBundle\Model\Adapter\AdapterInterface');
+        $adapter = $this->createMock(AdapterInterface::class);
         $adapter->expects($this->once())->method('getUrlsafeIdentifier')->will($this->returnValue('safe-parameter'));
 
         $extension = new TemplateExtension(true, $translator, $adapter);

--- a/tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
+++ b/tests/Twig/TokenParser/TemplateBoxTokenParserTest.php
@@ -14,6 +14,7 @@ namespace Sonata\CoreBundle\Tests\Twig\TokenParser;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Twig\Node\TemplateBoxNode;
 use Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class TemplateBoxTokenParserTest extends TestCase
 {
@@ -28,7 +29,7 @@ class TemplateBoxTokenParserTest extends TestCase
      */
     public function testCompile($enabled, $source, $expected)
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $env = new \Twig_Environment(new \Twig_Loader_Array([]), ['cache' => false, 'autoescape' => false, 'optimizations' => 0]);
         $env->addTokenParser(new TemplateBoxTokenParser($enabled, $translator));
@@ -49,7 +50,7 @@ class TemplateBoxTokenParserTest extends TestCase
 
     public function getTestsForRender()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
 
         return [
             [

--- a/tests/Validator/ErrorElementTest.php
+++ b/tests/Validator/ErrorElementTest.php
@@ -15,8 +15,12 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
@@ -30,7 +34,7 @@ class ErrorElementTest extends TestCase
 
     protected function setUp()
     {
-        $constraintValidatorFactory = $this->createMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
+        $constraintValidatorFactory = $this->createMock(ConstraintValidatorFactoryInterface::class);
 
         $this->context = $this->createMock(ExecutionContextInterface::class);
         $this->context->expects($this->once())
@@ -38,7 +42,7 @@ class ErrorElementTest extends TestCase
                 ->will($this->returnValue('bar'));
 
         if ($this->context instanceof ExecutionContextInterface) {
-            $builder = $this->createMock('Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface');
+            $builder = $this->createMock(ConstraintViolationBuilderInterface::class);
             $builder->expects($this->any())
                 ->method($this->anything())
                 ->will($this->returnSelf());
@@ -47,9 +51,9 @@ class ErrorElementTest extends TestCase
                 ->method('buildViolation')
                 ->willReturn($builder);
 
-            $validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+            $validator = $this->createMock(ValidatorInterface::class);
 
-            $this->contextualValidator = $this->createMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+            $this->contextualValidator = $this->createMock(ContextualValidatorInterface::class);
             $this->contextualValidator->expects($this->any())
                 ->method($this->anything())
                 ->will($this->returnSelf());
@@ -218,7 +222,7 @@ class ErrorElementTest extends TestCase
 
     public function testExceptionIsThrownWhenContextIsString()
     {
-        $constraintValidatorFactory = $this->createMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface');
+        $constraintValidatorFactory = $this->createMock(ConstraintValidatorFactoryInterface::class);
 
         $this->expectException(
             'InvalidArgumentException'

--- a/tests/Validator/InlineValidatorTest.php
+++ b/tests/Validator/InlineValidatorTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Tests\Fixtures\Bundle\Validator\FooValidatorService;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Validator\InlineValidator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
@@ -29,10 +32,8 @@ final class InlineValidatorTest extends TestCase
 
     public function setUp()
     {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->constraintValidatorFactory = $this->createMock(
-            'Symfony\Component\Validator\ConstraintValidatorFactoryInterface'
-        );
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->constraintValidatorFactory = $this->createMock(ConstraintValidatorFactoryInterface::class);
         $this->context = $this->createMock(ExecutionContextInterface::class);
     }
 
@@ -48,16 +49,16 @@ final class InlineValidatorTest extends TestCase
 
         $errorElement = $reflectedMethod->invokeArgs($inlineValidator, ['foo']);
 
-        $this->assertInstanceOf('Sonata\CoreBundle\Validator\ErrorElement', $errorElement);
+        $this->assertInstanceOf(ErrorElement::class, $errorElement);
         $this->assertSame('foo', $errorElement->getSubject());
     }
 
     public function testValidateWithConstraintIsClosure()
     {
-        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
+        $this->expectException(ValidatorException::class);
         $this->expectExceptionMessage('foo is equal to foo');
 
-        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+        $constraint = $this->getMockBuilder(Constraint::class)
             ->setMethods(['isClosure', 'getClosure'])
             ->getMock();
 
@@ -80,7 +81,7 @@ final class InlineValidatorTest extends TestCase
 
     public function testValidateWithConstraintGetServiceIsString()
     {
-        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+        $constraint = $this->getMockBuilder(Constraint::class)
             ->setMethods([
                 'isClosure',
                 'getService',
@@ -109,7 +110,7 @@ final class InlineValidatorTest extends TestCase
 
         $inlineValidator->initialize($this->context);
 
-        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
+        $this->expectException(ValidatorException::class);
         $this->expectExceptionMessage('foo is equal to foo');
 
         $inlineValidator->validate('foo', $constraint);
@@ -117,7 +118,7 @@ final class InlineValidatorTest extends TestCase
 
     public function testValidateWithConstraintGetServiceIsNotString()
     {
-        $constraint = $this->getMockBuilder('Symfony\Component\Validator\Constraint')
+        $constraint = $this->getMockBuilder(Constraint::class)
             ->setMethods([
                 'isClosure',
                 'getService',
@@ -141,7 +142,7 @@ final class InlineValidatorTest extends TestCase
 
         $inlineValidator->initialize($this->context);
 
-        $this->expectException('Symfony\Component\Validator\Exception\ValidatorException');
+        $this->expectException(ValidatorException::class);
         $this->expectExceptionMessage('foo is equal to foo');
 
         $inlineValidator->validate('foo', $constraint);


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```