### PR TITLE
Added close label to flash messages

### DIFF
--- a/src/Resources/translations/SonataCoreBundle.de.xliff
+++ b/src/Resources/translations/SonataCoreBundle.de.xliff
@@ -598,6 +598,10 @@
                 <source>yellowgreen</source>
                 <target>yellowgreen</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Schließen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataCoreBundle.en.xliff
+++ b/src/Resources/translations/SonataCoreBundle.en.xliff
@@ -598,6 +598,10 @@
                 <source>yellowgreen</source>
                 <target>YellowGreen</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Close</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataCoreBundle.fr.xliff
+++ b/src/Resources/translations/SonataCoreBundle.fr.xliff
@@ -598,6 +598,10 @@
                 <source>yellowgreen</source>
                 <target>YellowGreen</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Fermer</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/FlashMessage/render.html.twig
+++ b/src/Resources/views/FlashMessage/render.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
     {% set domain = domain is defined ? domain : null %}
     {% for message in sonata_flashmessages_get(type, domain) %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissable">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true" aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">&times;</button>
             {{ message|raw }}
         </div>
     {% endfor %}

--- a/src/Resources/views/FlashMessage/render.html.twig
+++ b/src/Resources/views/FlashMessage/render.html.twig
@@ -12,8 +12,12 @@ file that was distributed with this source code.
     {% set domain = domain is defined ? domain : null %}
     {% for message in sonata_flashmessages_get(type, domain) %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissable">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true"
-                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
+            <button
+                type="button"
+                class="close"
+                data-dismiss="alert"
+                aria-hidden="true"
+                aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
             >&times;</button>
             {{ message|raw }}
         </div>

--- a/src/Resources/views/FlashMessage/render.html.twig
+++ b/src/Resources/views/FlashMessage/render.html.twig
@@ -12,7 +12,9 @@ file that was distributed with this source code.
     {% set domain = domain is defined ? domain : null %}
     {% for message in sonata_flashmessages_get(type, domain) %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissable">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true" aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">&times;</button>
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true"
+                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
+            >&times;</button>
             {{ message|raw }}
         </div>
     {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added close label to flash messages

```

## Subject

According to [bootstrap](https://getbootstrap.com/docs/3.3/components/#alerts-dismissible), there should be a close label for users with assistive technologies.
