### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -8,11 +8,26 @@ The easiest way to install ``SonataCoreBundle`` is to require it with Composer:
 
 .. code-block:: bash
 
-    $ php composer.phar require sonata-project/core-bundle
+    $ composer require sonata-project/core-bundle
 
 Alternatively, you could add a dependency into your ``composer.json`` file directly.
 
-Now, enable the bundle in the kernel:
+Now, enable the bundle in ``bundles.php`` file:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Sonata\CoreBundle\SonataCoreBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
 
 .. code-block:: php
 
@@ -35,12 +50,16 @@ Configuration
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata.yaml
 
         sonata_core:
             form:
                 mapping:
                     enabled: false
+
+.. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.
 
 When using bootstrap, some widgets need to be wrapped in a special ``div`` element
 depending on whether you are using the standard style for your forms or the
@@ -53,10 +72,14 @@ corresponding configuration node accordingly:
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata.yaml
 
         sonata_core:
             form_type: horizontal
+
+.. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.
 
 Please note that if you are using the admin bundle, this is actually optional:
 The core bundle extension will detect if the configuration node that deals with


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.
