### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,13 +40,11 @@
     "require-dev": {
         "doctrine/orm": "^2.4",
         "doctrine/phpcr-odm": "^1.0",
-        "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
         "jms/serializer-bundle": "0.11 - 0.13 || ^1.0",
         "matthiasnoback/symfony-config-test": "^1.1",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7",
         "nelmio/api-doc-bundle": "^2.11",
-        "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "sonata-project/exporter": "^1.3",
         "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,12 @@
         "doctrine/orm": "^2.4",
         "doctrine/phpcr-odm": "^1.0",
         "jackalope/jackalope-doctrine-dbal": "^1.0",
-        "jms/serializer-bundle": "0.11 - 0.13 || ^1.0",
-        "matthiasnoback/symfony-config-test": "^1.1",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7",
+        "jms/serializer-bundle": "^1.0 || ^2.0",
+        "matthiasnoback/symfony-config-test": "^2.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.11",
         "sonata-project/exporter": "^1.3",
-        "symfony/phpunit-bridge": "^3.3.12 || ^4.0"
+        "symfony/phpunit-bridge": "^4.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Doing some archeology here:

- Removed FOSRestBundle and Sensio Framework Extra Bundle. They were added here: https://github.com/sonata-project/SonataCoreBundle/pull/45 but that code was removed here: https://github.com/sonata-project/SonataCoreBundle/commit/e781255d0b6ab661f9e041b01ff8d943ae70ebc0#diff-fdd764ee72f777e180ace83412a44158 without removing the dependencies. I cannot find any mention, and the tests does not show any difference without having those bundles installed.

- Allow newer versions of `serializer-bundle`, `symfony-config-test` and `matthiasnoback/symfony-dependency-injection-test`. This will allow us to add Symfony 4.0 to travis. With this changes all packages here are compatible with SF 4.0

- Upgrade PHPUnit bridge