### PR TITLE
Make services public

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.slugify.cocur" class="Cocur\Slugify\Slugify"/>
-        <service id="sonata.core.slugify.native" class="Sonata\CoreBundle\Component\NativeSlugify">
+        <service id="sonata.core.slugify.cocur" class="Cocur\Slugify\Slugify" public="true"/>
+        <service id="sonata.core.slugify.native" class="Sonata\CoreBundle\Component\NativeSlugify" public="true">
             <deprecated>The "%service_id%" service is deprecated since 2.3 and will be removed in 4.0.</deprecated>
         </service>
         <service id="sonata.core.form.extension.dependency" class="Sonata\CoreBundle\Form\Extension\DependencyInjectionExtension">


### PR DESCRIPTION
I am targeting this branch, because this is patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Services for slugify strings are marked as public
```
## Subject

Services `sonata.core.slugify.cocur` and `sonata.core.slugify.native` can be used in SonataPageBundle via container and must be public. See `Sonata\PageBundle\SonataPageBundle::boot`