### PR TITLE
Deprecate ColorType

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,9 @@
 UPGRADE 3.x
 ===========
 
+The `ColorType` class is deprecated. Use 
+`Symfony\Component\Form\Extension\Core\Type\ColorType` instead.
+
 UPGRADE FROM 3.6 to 3.7
 =======================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,8 @@ UPGRADE 3.x
 The `ColorType` class is deprecated. Use 
 `Symfony\Component\Form\Extension\Core\Type\ColorType` instead.
 
+The `Sonata\CoreBundle\Color\Colors` class is deprecated.
+
 UPGRADE FROM 3.6 to 3.7
 =======================
 

--- a/src/Color/Colors.php
+++ b/src/Color/Colors.php
@@ -11,9 +11,17 @@
 
 namespace Sonata\CoreBundle\Color;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\Colors class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
+
 /**
- * Handles A list of all HTML colors.
+ * NEXT_MAJOR: remove this class.
  *
+ * @deprecated since version 3.x, to be removed in 4.0.
+ *
+ * Handles A list of all HTML colors.
  * @see http://www.w3schools.com/HTML/html_colornames.asp
  *
  * @author Quentin Somazzi <qsomazzi@ekino.com>

--- a/src/Form/Type/ColorType.php
+++ b/src/Form/Type/ColorType.php
@@ -14,6 +14,19 @@ namespace Sonata\CoreBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
+if (class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ColorType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.',
+        E_USER_DEPRECATED
+    );
+}
+
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 3.x, to be removed in 4.0. Use Symfony\Component\Form\Extension\Core\Type\ColorType instead
+ */
 final class ColorType extends AbstractType
 {
     public function getParent()

--- a/tests/Form/Type/ColorSelectorTypeTest.php
+++ b/tests/Form/Type/ColorSelectorTypeTest.php
@@ -23,6 +23,7 @@ class ColorSelectorTypeTest extends TypeTestCase
 {
     /**
      * @group legacy
+     * @expectedDeprecation The Sonata\CoreBundle\Color\Colors class is deprecated since version 3.x and will be removed in 4.0.
      */
     public function testBuildForm()
     {

--- a/tests/Form/Type/ColorTypeTest.php
+++ b/tests/Form/Type/ColorTypeTest.php
@@ -15,6 +15,9 @@ use Sonata\CoreBundle\Form\Type\ColorType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\Test\TypeTestCase;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ */
 class ColorTypeTest extends TypeTestCase
 {
     public function testBuildForm()

--- a/tests/Form/Type/ColorTypeTest.php
+++ b/tests/Form/Type/ColorTypeTest.php
@@ -20,6 +20,19 @@ use Symfony\Component\Form\Test\TypeTestCase;
  */
 class ColorTypeTest extends TypeTestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\CoreBundle\Form\Type\ColorType class is deprecated since version 3.x and will be removed in 4.0. Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.
+     */
+    public function testDeprecation()
+    {
+        if (!class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
+            $this->markTestSkipped('< Symfony 3.4');
+        }
+
+        $type = new ColorType();
+    }
+
     public function testBuildForm()
     {
         $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is deprecation notice.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- ColorType has been deprecated
- Colors class has been deprecated
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Add an upgrade note

## Subject

Symfony 3.4 provides the same form type so we do not need it anymore, deprecation will be triggered only if the class exists.
