### PR TITLE
SonataListFormMappingCommand is enabled on symfony v4

### DIFF
--- a/src/Command/SonataListFormMappingCommand.php
+++ b/src/Command/SonataListFormMappingCommand.php
@@ -29,7 +29,7 @@ class SonataListFormMappingCommand extends ContainerAwareCommand
 
     public function isEnabled()
     {
-        return Kernel::MAJOR_VERSION !== 3;
+        return Kernel::MAJOR_VERSION < 3;
     }
 
     protected function configure()


### PR DESCRIPTION

SonataListFormMappingCommand is enabled on symfony v4, this commit fix it.


I am targeting this branch, because has no BC.

Closes #533

## Changelog
### Fixed
SonataListFormMappingCommand::isEnabled to only enable the command when Symfony Major Version < 3

