### PR TITLE
Minor Date(Time)PickerType integration improvement

### DIFF
--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -72,7 +72,7 @@ abstract class BasePickerType extends AbstractType
         if (isset($options['date_format']) && is_string($options['date_format'])) {
             $format = $options['date_format'];
         } elseif (is_int($format)) {
-            $timeFormat = ($options['dp_pick_time']) ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::NONE;
+            $timeFormat = ($options['dp_pick_time']) ? ($options['dp_use_seconds'] ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::SHORT) : \IntlDateFormatter::NONE;
             $intlDateFormatter = new \IntlDateFormatter(
                 \Locale::getDefault(),
                 $format,

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -72,9 +72,12 @@ abstract class BasePickerType extends AbstractType
         if (isset($options['date_format']) && is_string($options['date_format'])) {
             $format = $options['date_format'];
         } elseif (is_int($format)) {
-            $timeFormat = ($options['dp_pick_time']) ? ($options['dp_use_seconds'] ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::SHORT) : \IntlDateFormatter::NONE;
+            $timeFormat = \IntlDateFormatter::NONE;
+            if ($options['dp_pick_time']) {
+                $timeFormat = $options['dp_use_seconds'] ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::SHORT;
+            }
             $intlDateFormatter = new \IntlDateFormatter(
-                \Locale::getDefault(),
+                $this->locale,
                 $format,
                 $timeFormat,
                 null,

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -87,6 +87,13 @@ abstract class BasePickerType extends AbstractType
         // use seconds if it's allowed in format
         $options['dp_use_seconds'] = false !== strpos($format, 's');
 
+        if ($options['dp_min_date'] instanceof \DateTime) {
+            $options['dp_min_date'] = \IntlDateFormatter::formatObject($options['dp_min_date'], $format, $this->locale);
+        }
+        if ($options['dp_max_date'] instanceof \DateTime) {
+            $options['dp_max_date'] = \IntlDateFormatter::formatObject($options['dp_max_date'], $format, $this->locale);
+        }
+
         $view->vars['moment_format'] = $this->formatConverter->convert($format);
 
         $view->vars['type'] = 'text';

--- a/src/Form/Type/DateRangePickerType.php
+++ b/src/Form/Type/DateRangePickerType.php
@@ -25,7 +25,9 @@ class DateRangePickerType extends DateRangeType
         $resolver->setDefaults([
             'field_options' => [],
             'field_options_start' => [],
-            'field_options_end' => [],
+            'field_options_end' => [
+                'dp_use_current' => false,
+            ],
             'field_type' => DatePickerType::class,
         ]);
     }

--- a/src/Form/Type/DateTimeRangePickerType.php
+++ b/src/Form/Type/DateTimeRangePickerType.php
@@ -25,7 +25,9 @@ class DateTimeRangePickerType extends DateTimeRangeType
         $resolver->setDefaults([
             'field_options' => [],
             'field_options_start' => [],
-            'field_options_end' => [],
+            'field_options_end' => [
+                'dp_use_current' => false,
+            ],
             'field_type' => DateTimePickerType::class,
         ]);
     }

--- a/src/Resources/views/Form/datepicker.html.twig
+++ b/src/Resources/views/Form/datepicker.html.twig
@@ -37,6 +37,24 @@ file that was distributed with this source code.
     {% endspaceless %}
 {% endblock sonata_type_date_picker_widget %}
 
+{% block sonata_type_date_range_picker_widget %}
+    {% spaceless %}
+        {{ block('form_widget') }}
+        <script type="text/javascript">
+            jQuery(function ($) {
+                var $startDateTimePicker = $('#{{ form.children.start.vars.datepicker_use_button ? 'dp_' : '' }}{{ form.children.start.vars.id }}');
+                var $endDateTimePicker = $('#{{ form.children.end.vars.datepicker_use_button ? 'dp_' : '' }}{{ form.children.end.vars.id }}');
+                $startDateTimePicker.on("dp.change", function (e) {
+                    $endDateTimePicker.data("DateTimePicker").setMinDate(e.date);
+                });
+                $endDateTimePicker.on("dp.change", function (e) {
+                    $startDateTimePicker.data("DateTimePicker").setMaxDate(e.date);
+                });
+            });
+        </script>
+    {% endspaceless %}
+{% endblock sonata_type_date_range_picker_widget %}
+
 {% block sonata_type_datetime_picker_widget_html %}
     {% if datepicker_use_button %}
         <div class='input-group date {% if not dp_options['pickDate'] %}timepicker{% endif %}' id='dtp_{{ id }}'>
@@ -67,3 +85,21 @@ file that was distributed with this source code.
         </script>
     {% endspaceless %}
 {% endblock sonata_type_datetime_picker_widget %}
+
+{% block sonata_type_datetime_range_picker_widget %}
+    {% spaceless %}
+    {{ block('form_widget') }}
+        <script type="text/javascript">
+            jQuery(function ($) {
+                var $startDateTimePicker = $('#{{ form.children.start.vars.datepicker_use_button ? 'dtp_' : '' }}{{ form.children.start.vars.id }}');
+                var $endDateTimePicker = $('#{{ form.children.end.vars.datepicker_use_button ? 'dtp_' : '' }}{{ form.children.end.vars.id }}');
+                $startDateTimePicker.on("dp.change", function (e) {
+                    $endDateTimePicker.data("DateTimePicker").setMinDate(e.date);
+                });
+                $endDateTimePicker.on("dp.change", function (e) {
+                    $startDateTimePicker.data("DateTimePicker").setMaxDate(e.date);
+                });
+            });
+        </script>
+    {% endspaceless %}
+{% endblock sonata_type_datetime_range_picker_widget %}

--- a/src/Resources/views/Form/datepicker.html.twig
+++ b/src/Resources/views/Form/datepicker.html.twig
@@ -37,24 +37,6 @@ file that was distributed with this source code.
     {% endspaceless %}
 {% endblock sonata_type_date_picker_widget %}
 
-{% block sonata_type_date_range_picker_widget %}
-    {% spaceless %}
-        {{ block('form_widget') }}
-        <script type="text/javascript">
-            jQuery(function ($) {
-                var $startDateTimePicker = $('#{{ form.children.start.vars.datepicker_use_button ? 'dp_' : '' }}{{ form.children.start.vars.id }}');
-                var $endDateTimePicker = $('#{{ form.children.end.vars.datepicker_use_button ? 'dp_' : '' }}{{ form.children.end.vars.id }}');
-                $startDateTimePicker.on("dp.change", function (e) {
-                    $endDateTimePicker.data("DateTimePicker").setMinDate(e.date);
-                });
-                $endDateTimePicker.on("dp.change", function (e) {
-                    $startDateTimePicker.data("DateTimePicker").setMaxDate(e.date);
-                });
-            });
-        </script>
-    {% endspaceless %}
-{% endblock sonata_type_date_range_picker_widget %}
-
 {% block sonata_type_datetime_picker_widget_html %}
     {% if datepicker_use_button %}
         <div class='input-group date {% if not dp_options['pickDate'] %}timepicker{% endif %}' id='dtp_{{ id }}'>
@@ -86,13 +68,13 @@ file that was distributed with this source code.
     {% endspaceless %}
 {% endblock sonata_type_datetime_picker_widget %}
 
-{% block sonata_type_datetime_range_picker_widget %}
+{% block sonata_type_datetime_range_script_block %}
     {% spaceless %}
-    {{ block('form_widget') }}
+        {{ block('form_widget') }}
         <script type="text/javascript">
             jQuery(function ($) {
-                var $startDateTimePicker = $('#{{ form.children.start.vars.datepicker_use_button ? 'dtp_' : '' }}{{ form.children.start.vars.id }}');
-                var $endDateTimePicker = $('#{{ form.children.end.vars.datepicker_use_button ? 'dtp_' : '' }}{{ form.children.end.vars.id }}');
+                var $startDateTimePicker = $('#{{ startId }}');
+                var $endDateTimePicker = $('#{{ endId }}');
                 $startDateTimePicker.on("dp.change", function (e) {
                     $endDateTimePicker.data("DateTimePicker").setMinDate(e.date);
                 });
@@ -102,4 +84,16 @@ file that was distributed with this source code.
             });
         </script>
     {% endspaceless %}
+{% endblock sonata_type_datetime_range_script_block %}
+
+{% block sonata_type_datetime_range_picker_widget %}
+    {% set startId = (form.children.start.vars.datepicker_use_button ? 'dtp_' : '') ~ form.children.start.vars.id %}
+    {% set endId = (form.children.end.vars.datepicker_use_button ? 'dtp_' : '') ~ form.children.end.vars.id %}
+    {{ block('sonata_type_datetime_range_script_block') }}
 {% endblock sonata_type_datetime_range_picker_widget %}
+
+{% block sonata_type_date_range_picker_widget %}
+    {% set startId = (form.children.start.vars.datepicker_use_button ? 'dp_' : '') ~ form.children.start.vars.id %}
+    {% set endId = (form.children.end.vars.datepicker_use_button ? 'dp_' : '') ~ form.children.end.vars.id %}
+    {{ block('sonata_type_datetime_range_script_block') }}
+{% endblock sonata_type_date_range_picker_widget %}

--- a/tests/Form/Type/BasePickerTypeTest.php
+++ b/tests/Form/Type/BasePickerTypeTest.php
@@ -48,11 +48,19 @@ class BasePickerTypeTest extends TestCase
         $view = new FormView();
         $form = new Form($this->createMock(FormConfigInterface::class));
 
-        $type->finishView($view, $form, ['format' => 'yyyy-MM-dd']);
+        $type->finishView($view, $form, [
+            'format' => 'yyyy-MM-dd',
+            'dp_min_date' => '1/1/1900',
+            'dp_max_date' => new \DateTime('1/1/2001'),
+            'dp_use_seconds' => true,
+        ]);
 
         $this->assertArrayHasKey('moment_format', $view->vars);
         $this->assertArrayHasKey('dp_options', $view->vars);
         $this->assertArrayHasKey('datepicker_use_button', $view->vars);
+        $this->assertFalse($view->vars['dp_options']['useSeconds']);
+        $this->assertSame('1/1/1900', $view->vars['dp_options']['minDate']);
+        $this->assertSame('2001-01-01', $view->vars['dp_options']['maxDate']);
 
         foreach ($view->vars['dp_options'] as $dpKey => $dpValue) {
             $this->assertFalse(strpos($dpKey, '_'));
@@ -60,6 +68,30 @@ class BasePickerTypeTest extends TestCase
         }
 
         $this->assertSame('text', $view->vars['type']);
+    }
+
+    public function testTimePickerIntlFormater()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('getLocale')->willReturn('ru');
+
+        $type = new BasePickerTest(new MomentFormatConverter(), $translator);
+
+        $view = new FormView();
+        $form = new Form($this->createMock(FormConfigInterface::class));
+
+        $type->finishView($view, $form, [
+            'format' => \IntlDateFormatter::NONE,
+            'dp_min_date' => '1/1/1900',
+            'dp_max_date' => new \DateTime('3/1/2001'),
+            'dp_use_seconds' => false,
+            'dp_pick_time' => true,
+            'dp_pick_date' => false,
+        ]);
+
+        $this->assertFalse($view->vars['dp_options']['useSeconds']);
+        $this->assertSame('H:mm', $view->vars['moment_format']);
+        $this->assertSame('0:00', $view->vars['dp_options']['maxDate']);
     }
 
     /**

--- a/tests/Form/Type/DateRangePickerTypeTest.php
+++ b/tests/Form/Type/DateRangePickerTypeTest.php
@@ -65,7 +65,9 @@ class DateRangePickerTypeTest extends TypeTestCase
             [
                 'field_options' => [],
                 'field_options_start' => [],
-                'field_options_end' => [],
+                'field_options_end' => [
+                    'dp_use_current' => false,
+                ],
                 'field_type' => DatePickerType::class,
             ], $options);
     }

--- a/tests/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/tests/Form/Type/DateTimeRangePickerTypeTest.php
@@ -65,7 +65,9 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
             [
                 'field_options' => [],
                 'field_options_start' => [],
-                'field_options_end' => [],
+                'field_options_end' => [
+                    'dp_use_current' => false,
+                ],
                 'field_type' => DateTimePickerType::class,
             ], $options);
     }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

```markdown
### Added
- [Date(Time)PickerType] Handle field without seconds with option dp_use_seconds.
- [Date(Time)PickerType] Allow DateTime Object in dp_min_date and dp_max_date
- [Date(Time)RangePickerType] Link DateTimeRange pickers to keep start < end
```

## Subject
Small update on the Date(Time)PickerType to 
- allow define field without seconds, and keep Intl localization (use IntlDateFormatter::SHORT).
- usage of Php \DateTime Object instead of string in the min & max values
- Range type are now linked together like described https://eonasdan.github.io/bootstrap-datetimepicker/#linked-pickers
