### PR TITLE
DateTimePicker format

### DIFF
--- a/src/Form/Type/DatePickerType.php
+++ b/src/Form/Type/DatePickerType.php
@@ -36,6 +36,8 @@ class DatePickerType extends BasePickerType
             'dp_pick_time' => false,
             'format' => DateType::DEFAULT_FORMAT,
         ]));
+
+        parent::configureOptions($resolver);
     }
 
     public function getParent()

--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -39,6 +39,8 @@ class DateTimePickerType extends BasePickerType
             'format' => DateTimeType::DEFAULT_DATE_FORMAT,
             'date_format' => null,
         ]));
+
+        parent::configureOptions($resolver);
     }
 
     public function getParent()

--- a/tests/Form/Type/BasePickerTypeTest.php
+++ b/tests/Form/Type/BasePickerTypeTest.php
@@ -81,10 +81,9 @@ class BasePickerTypeTest extends TestCase
         $form = new Form($this->createMock(FormConfigInterface::class));
 
         $type->finishView($view, $form, [
-            'format' => \IntlDateFormatter::NONE,
+            'format' => 'H:mm',
             'dp_min_date' => '1/1/1900',
             'dp_max_date' => new \DateTime('3/1/2001'),
-            'dp_use_seconds' => false,
             'dp_pick_time' => true,
             'dp_pick_date' => false,
         ]);

--- a/tests/Form/Type/DatePickerTypeTest.php
+++ b/tests/Form/Type/DatePickerTypeTest.php
@@ -11,17 +11,18 @@
 
 namespace Sonata\CoreBundle\Tests\Form\Type;
 
-use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Date\MomentFormatConverter;
 use Sonata\CoreBundle\Form\Type\DatePickerType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class DatePickerTypeTest extends TestCase
+class DatePickerTypeTest extends TypeTestCase
 {
     public function testBuildForm()
     {
@@ -72,5 +73,30 @@ class DatePickerTypeTest extends TestCase
         $type = new DatePickerType(new MomentFormatConverter());
 
         $this->assertSame('sonata_type_date_picker', $type->getName());
+    }
+
+    public function testSubmitValidData()
+    {
+        \Locale::setDefault('en');
+        $form = $this->factory->create(DatePickerType::class, new \DateTime('2018-06-03'), [
+            'format' => \IntlDateFormatter::LONG,
+        ]);
+
+        $this->assertSame('June 3, 2018', $form->getViewData());
+        $form->submit('June 5, 2018');
+        $this->assertSame('2018-06-05', $form->getData()->format('Y-m-d'));
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    protected function getExtensions()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('getLocale')->willReturn('en');
+
+        $type = new DatePickerType(new MomentFormatConverter(), $translator);
+
+        return [
+            new PreloadedExtension([$type], []),
+        ];
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is not a BC-break, and this is a bugfix.

## Changelog

```markdown
### Fixed
- fix DateTimePickerType format usage of Intl constants.
```

It was possible to set the date format in DatePicker & DateTimePicker by using Intl const \IntlDateFormatter::NONE / SHORT / ...
It worked properly for DatePicker but not for DateTimePicker. On submit the symfony FormType wasn't able to parse the string as the format configured was not defined in the DateTimeType ViewTransformer.
