### PR TITLE
#545 Fix fputcsv() default escape character

### DIFF
--- a/src/Exporter/Exporter.php
+++ b/src/Exporter/Exporter.php
@@ -57,7 +57,7 @@ class Exporter
 
                 break;
             case 'csv':
-                $writer = new CsvWriter('php://output', ',', '"', '', true, true);
+                $writer = new CsvWriter('php://output', ',', '"', '\\', true, true);
                 $contentType = 'text/csv';
 
                 break;

--- a/tests/Form/Type/BooleanTypeTest.php
+++ b/tests/Form/Type/BooleanTypeTest.php
@@ -76,7 +76,7 @@ class BooleanTypeTest extends TypeTestCase
 
         $options = $optionResolver->resolve();
 
-        $this->assertSame(2, count($options['choices']));
+        $this->assertCount(2, $options['choices']);
     }
 
     public function testAddTransformerCall()

--- a/tests/Form/Type/CollectionTypeTest.php
+++ b/tests/Form/Type/CollectionTypeTest.php
@@ -63,7 +63,7 @@ class CollectionTypeTest extends TypeTestCase
 
         $this->assertFalse($options['modifiable']);
         $this->assertSame(TextType::class, $options['type']);
-        $this->assertSame(0, count($options['type_options']));
+        $this->assertCount(0, $options['type_options']);
         $this->assertSame('link_add', $options['btn_add']);
         $this->assertSame('SonataCoreBundle', $options['btn_catalogue']);
         $this->assertNull($options['pre_bind_data_callback']);


### PR DESCRIPTION
I am targeting this branch, because CSV export is broken in it.

Closes #545

## Changelog
### Fixed
- fputcsv() default escape character

## Subject

The problem is in an exporter: [default escape value is empty string](https://github.com/sonata-project/SonataCoreBundle/blob/3.x/src/Exporter/Exporter.php#L60) which is illegal for [fputcsv](http://php.net/manual/en/function.fputcsv.php) function:

> **escape_char**
The optional escape_char parameter sets the escape character (one character only).

The error is: `Warning: fputcsv(): escape must be a character`

Version details:
```
composer show --latest 'sonata-project/*' | grep core-bundle
sonata-project/core-bundle               3.9.1  = 3.9.1  Symfony SonataCoreBundle
```
