### PR TITLE
Remove strong dependency on session

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,6 +6,14 @@ The `ColorType` class is deprecated. Use
 
 The `Sonata\CoreBundle\Color\Colors` class is deprecated.
 
+A runtime has been introduced to lazy-load some extensions dependencies:
+    - The methods `getFlashMessages()` and `getFlashMessagesTypes` of class
+      `Sonata\CoreBundle\Twig\Extension\FlashMessageExtension` are deprecated.
+    - The method `statusClass()` of class `Sonata\CoreBundle\Twig\Extension\StatusExtension`
+      is deprecated.
+
+Instead, use the associated runtimes: `FlashMessageRuntime` and `StatusRuntime`.
+
 UPGRADE FROM 3.6 to 3.7
 =======================
 

--- a/src/DependencyInjection/Compiler/StatusRendererCompilerPass.php
+++ b/src/DependencyInjection/Compiler/StatusRendererCompilerPass.php
@@ -24,7 +24,7 @@ class StatusRendererCompilerPass implements CompilerPassInterface
     {
         foreach ($container->findTaggedServiceIds('sonata.status.renderer') as $id => $attributes) {
             $container
-                ->getDefinition('sonata.core.twig.status_extension')
+                ->getDefinition('sonata.core.twig.status_runtime')
                 ->addMethodCall('addStatusService', [new Reference($id)])
             ;
         }

--- a/src/Resources/config/flash.xml
+++ b/src/Resources/config/flash.xml
@@ -12,9 +12,12 @@
             <argument/>
             <argument/>
         </service>
+        <service id="sonata.core.flashmessage.twig.runtime" class="Sonata\CoreBundle\Twig\Extension\FlashMessageRuntime">
+            <tag name="twig.runtime"/>
+            <argument type="service" id="sonata.core.flashmessage.manager"/>
+        </service>
         <service id="sonata.core.flashmessage.twig.extension" class="%sonata.core.twig.extension.flashmessage.class%" public="true">
             <tag name="twig.extension"/>
-            <argument type="service" id="sonata.core.flashmessage.manager"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -9,6 +9,9 @@
         <service id="sonata.core.twig.extension.text" class="Sonata\CoreBundle\Twig\Extension\DeprecatedTextExtension">
             <tag name="twig.extension"/>
         </service>
+        <service id="sonata.core.twig.status_runtime" class="Sonata\CoreBundle\Twig\Extension\StatusRuntime">
+            <tag name="twig.runtime"/>
+        </service>
         <service id="sonata.core.twig.status_extension" class="Sonata\CoreBundle\Twig\Extension\StatusExtension">
             <tag name="twig.extension"/>
         </service>

--- a/src/Twig/Extension/FlashMessageExtension.php
+++ b/src/Twig/Extension/FlashMessageExtension.php
@@ -19,6 +19,7 @@ use Twig\TwigFunction;
  * This is the Sonata core flash message Twig extension.
  *
  * @author Vincent Composieux <composieux@ekino.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 class FlashMessageExtension extends AbstractExtension
 {
@@ -27,16 +28,31 @@ class FlashMessageExtension extends AbstractExtension
      */
     protected $flashManager;
 
-    public function __construct(FlashManager $flashManager)
+    public function __construct(FlashManager $flashManager = null)
     {
         $this->flashManager = $flashManager;
+
+        if ($this->flashManager) {
+            @trigger_error(
+                'Argument "flashManager" in FlashMessageExtension is deprecated since SonataCoreBundle 3.x and will'.
+                ' be removed in 4.0. Use the FlashMessageRuntime instead.',
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     public function getFunctions()
     {
+        if ($this->flashManager) {
+            return [
+                new TwigFunction('sonata_flashmessages_get', [$this, 'getFlashMessages']),
+                new TwigFunction('sonata_flashmessages_types', [$this, 'getFlashMessagesTypes']),
+            ];
+        }
+
         return [
-            new TwigFunction('sonata_flashmessages_get', [$this, 'getFlashMessages']),
-            new TwigFunction('sonata_flashmessages_types', [$this, 'getFlashMessagesTypes']),
+            new TwigFunction('sonata_flashmessages_get', [FlashMessageRuntime::class, 'getFlashMessages']),
+            new TwigFunction('sonata_flashmessages_types', [FlashMessageRuntime::class, 'getFlashMessagesTypes']),
         ];
     }
 
@@ -47,9 +63,17 @@ class FlashMessageExtension extends AbstractExtension
      * @param string $domain Translation domain to use
      *
      * @return string
+     *
+     * @deprecated since 3.x, to be removed in 4.0. Use the FlashMessageRuntime instead.
      */
     public function getFlashMessages($type, $domain = null)
     {
+        @trigger_error(
+            'Method "FlashMessageExtension::getFlashMessages()" is deprecated since SonataCoreBundle 3.x and will'.
+            ' be removed in 4.0. Use the FlashMessageRuntime instead.',
+            E_USER_DEPRECATED
+        );
+
         return $this->flashManager->get($type, $domain);
     }
 
@@ -57,9 +81,17 @@ class FlashMessageExtension extends AbstractExtension
      * Returns flash messages types handled by Sonata core flash manager.
      *
      * @return string
+     *
+     * @deprecated since 3.x, to be removed in 4.0. Use the FlashMessageRuntime instead.
      */
     public function getFlashMessagesTypes()
     {
+        @trigger_error(
+            'Method "FlashMessageExtension::getFlashMessagesTypes()" is deprecated since SonataCoreBundle 3.x and will'.
+            ' be removed in 4.0. Use the FlashMessageRuntime instead.',
+            E_USER_DEPRECATED
+        );
+
         return $this->flashManager->getHandledTypes();
     }
 

--- a/src/Twig/Extension/FlashMessageRuntime.php
+++ b/src/Twig/Extension/FlashMessageRuntime.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Twig\Extension;
+
+use Sonata\CoreBundle\FlashMessage\FlashManager;
+
+/**
+ * This is the Sonata core flash message Twig runtime.
+ *
+ * @author Vincent Composieux <composieux@ekino.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class FlashMessageRuntime
+{
+    private $flashManager;
+
+    public function __construct(FlashManager $flashManager)
+    {
+        $this->flashManager = $flashManager;
+    }
+
+    /**
+     * Returns flash messages handled by Sonata core flash manager.
+     *
+     * @param string $type   Type of flash message
+     * @param string $domain Translation domain to use
+     *
+     * @return string
+     */
+    public function getFlashMessages($type, $domain = null)
+    {
+        return $this->flashManager->get($type, $domain);
+    }
+
+    /**
+     * Returns flash messages types handled by Sonata core flash manager.
+     *
+     * @return string
+     */
+    public function getFlashMessagesTypes()
+    {
+        return $this->flashManager->getHandledTypes();
+    }
+}

--- a/src/Twig/Extension/StatusExtension.php
+++ b/src/Twig/Extension/StatusExtension.php
@@ -16,6 +16,7 @@ use Twig\Extension\AbstractExtension;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 class StatusExtension extends AbstractExtension
 {
@@ -28,16 +29,30 @@ class StatusExtension extends AbstractExtension
      * Adds a renderer to the status services list.
      *
      * @param StatusClassRendererInterface $renderer
+     *
+     * @deprecated since 3.x, to be removed in 4.0. Use the StatusRuntime instead.
      */
     public function addStatusService(StatusClassRendererInterface $renderer)
     {
+        @trigger_error(
+            'Method "StatusExtension::addStatusService()" is deprecated since SonataCoreBundle 3.x and will'.
+            ' be removed in 4.0. Use the StatusRuntime instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->statusServices[] = $renderer;
     }
 
     public function getFilters()
     {
+        if (!empty($this->statusServices)) {
+            return [
+                new \Twig_SimpleFilter('sonata_status_class', [$this, 'statusClass']),
+            ];
+        }
+
         return [
-            new \Twig_SimpleFilter('sonata_status_class', [$this, 'statusClass']),
+            new \Twig_SimpleFilter('sonata_status_class', [StatusRuntime::class, 'statusClass']),
         ];
     }
 
@@ -47,9 +62,17 @@ class StatusExtension extends AbstractExtension
      * @param string $default
      *
      * @return string
+     *
+     * @deprecated since 3.x, to be removed in 4.0. Use the StatusRuntime instead.
      */
     public function statusClass($object, $statusType = null, $default = '')
     {
+        @trigger_error(
+            'Method "StatusExtension::statusClass()" is deprecated since SonataCoreBundle 3.x and will'.
+            ' be removed in 4.0. Use the StatusRuntime instead.',
+            E_USER_DEPRECATED
+        );
+
         /** @var StatusClassRendererInterface $statusService */
         foreach ($this->statusServices as $statusService) {
             if ($statusService->handlesObject($object, $statusType)) {

--- a/src/Twig/Extension/StatusRuntime.php
+++ b/src/Twig/Extension/StatusRuntime.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Twig\Extension;
+
+use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+
+/**
+ * @author Hugo Briand <briand@ekino.com>
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+final class StatusRuntime
+{
+    /**
+     * @var StatusClassRendererInterface[]
+     */
+    private $statusServices = [];
+
+    /**
+     * Adds a renderer to the status services list.
+     */
+    public function addStatusService(StatusClassRendererInterface $renderer)
+    {
+        $this->statusServices[] = $renderer;
+    }
+
+    /**
+     * @param mixed  $object
+     * @param mixed  $statusType
+     * @param string $default
+     *
+     * @return string
+     */
+    public function statusClass($object, $statusType = null, $default = '')
+    {
+        foreach ($this->statusServices as $statusService) {
+            assert($statusService instanceof StatusClassRendererInterface);
+
+            if ($statusService->handlesObject($object, $statusType)) {
+                return $statusService->getStatusClass($object, $statusType, $default);
+            }
+        }
+
+        return $default;
+    }
+}

--- a/tests/DependencyInjection/Compiler/StatusRendererCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/StatusRendererCompilerPassTest.php
@@ -34,12 +34,12 @@ final class StatusRendererCompilerPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('sonata.status.renderer', $statusRenderer);
 
         $statusExtension = new Definition();
-        $this->setDefinition('sonata.core.twig.status_extension', $statusExtension);
+        $this->setDefinition('sonata.core.twig.status_runtime', $statusExtension);
 
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.core.twig.status_extension',
+            'sonata.core.twig.status_runtime',
             'addStatusService',
             [new Reference('sonata.status.renderer')]
         );

--- a/tests/Twig/Extension/FlashMessageExtensionTest.php
+++ b/tests/Twig/Extension/FlashMessageExtensionTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\CoreBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\FlashMessage\FlashManager;
 use Sonata\CoreBundle\Twig\Extension\FlashMessageExtension;
 
 class FlashMessageExtensionTest extends TestCase
@@ -21,9 +20,7 @@ class FlashMessageExtensionTest extends TestCase
 
     protected function setUp()
     {
-        $this->extension = new FlashMessageExtension(
-            $this->prophesize(FlashManager::class)->reveal()
-        );
+        $this->extension = new FlashMessageExtension();
     }
 
     public function testFunctionsArePrefixed()

--- a/tests/Twig/Extension/StatusExtensionTest.php
+++ b/tests/Twig/Extension/StatusExtensionTest.php
@@ -14,6 +14,7 @@ namespace Sonata\CoreBundle\Tests\Twig\Extension;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
 use Sonata\CoreBundle\Twig\Extension\StatusExtension;
+use Sonata\CoreBundle\Twig\Extension\StatusRuntime;
 
 class StatusExtensionTest extends TestCase
 {
@@ -33,7 +34,7 @@ class StatusExtensionTest extends TestCase
 
     public function testStatusClassDefaultValue()
     {
-        $extension = new StatusExtension();
+        $extension = new StatusRuntime();
         $statusService = $this->getMockBuilder(StatusClassRendererInterface::class)
             ->getMock();
         $statusService->expects($this->once())


### PR DESCRIPTION
I am targeting 3.x because this PR is BC-compatible and fix a bug with some session handlers.

## Changelog

```markdown
### Added
- Added `FlashMessageRuntime` and `StatusRuntime` to remove strong dependency on the session introduced by Twig extensions
```

## Subject

Two Twig extensions of SonataCoreBundle relies on the session through the flash messages manager. In some contexts such as when sessions are stored in Redis and we try to warmup the cache in CLI without Redis available, this makes the process fails.

This PR fixes this by using Twig runtimes instead of a direct extension to avoid a strong dependency on the flash messages manager.