### PR TITLE
Fix compatibility with Symfony 2.8

### DIFF
--- a/src/DependencyInjection/Compiler/FlashMessageCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FlashMessageCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * NEXT_MAJOR : remove this class when dropping support for Symfony 2.8.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class FlashMessageCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(RuntimeLoaderPass::class) && $container->hasDefinition('sonata.core.flashmessage.twig.extension')) {
+            $container->getDefinition('sonata.core.flashmessage.twig.extension')
+                ->setArguments([new Reference('sonata.core.flashmessage.manager')]);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/StatusRendererCompilerPass.php
+++ b/src/DependencyInjection/Compiler/StatusRendererCompilerPass.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\CoreBundle\DependencyInjection\Compiler;
 
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,11 +23,23 @@ class StatusRendererCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        // NEXT_MAJOR : remove this check when dropping support for Symfony 2.8.
+        if (class_exists(RuntimeLoaderPass::class)) {
+            if (!$container->hasDefinition('sonata.core.twig.status_runtime')) {
+                return;
+            }
+
+            $definition = $container->getDefinition('sonata.core.twig.status_runtime');
+        } else {
+            if (!$container->hasDefinition('sonata.core.twig.status_extension')) {
+                return;
+            }
+
+            $definition = $container->getDefinition('sonata.core.twig.status_extension');
+        }
+
         foreach ($container->findTaggedServiceIds('sonata.status.renderer') as $id => $attributes) {
-            $container
-                ->getDefinition('sonata.core.twig.status_runtime')
-                ->addMethodCall('addStatusService', [new Reference($id)])
-            ;
+            $definition->addMethodCall('addStatusService', [new Reference($id)]);
         }
     }
 }

--- a/src/SonataCoreBundle.php
+++ b/src/SonataCoreBundle.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle;
 
 use Nelmio\ApiDocBundle\Form\Extension\DescriptionFormTypeExtension;
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
+use Sonata\CoreBundle\DependencyInjection\Compiler\FlashMessageCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
@@ -68,6 +69,7 @@ class SonataCoreBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new StatusRendererCompilerPass());
+        $container->addCompilerPass(new FlashMessageCompilerPass());
         $container->addCompilerPass(new AdapterCompilerPass());
         $container->addCompilerPass(new FormFactoryCompilerPass());
 

--- a/tests/DependencyInjection/Compiler/FlashMessageCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/FlashMessageCompilerPassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\CoreBundle\DependencyInjection\Compiler\FlashMessageCompilerPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\RuntimeLoaderPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @group legacy
+ */
+final class FlashMessageCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new FlashMessageCompilerPass());
+    }
+
+    public function testProcess()
+    {
+        $this->setDefinition('sonata.core.flashmessage.twig.extension', new Definition());
+
+        $this->compile();
+
+        $definition = $this->container->getDefinition('sonata.core.flashmessage.twig.extension');
+        if (!class_exists(RuntimeLoaderPass::class)) {
+            $this->assertCount(1, $definition->getArguments());
+        } else {
+            $this->assertCount(0, $definition->getArguments());
+        }
+    }
+}

--- a/tests/DependencyInjection/Compiler/StatusRendererCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/StatusRendererCompilerPassTest.php
@@ -34,14 +34,23 @@ final class StatusRendererCompilerPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('sonata.status.renderer', $statusRenderer);
 
         $statusExtension = new Definition();
+        $this->setDefinition('sonata.core.twig.status_extension', $statusExtension);
         $this->setDefinition('sonata.core.twig.status_runtime', $statusExtension);
 
         $this->compile();
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.core.twig.status_runtime',
-            'addStatusService',
-            [new Reference('sonata.status.renderer')]
-        );
+        if (!class_exists(RuntimeLoaderPass::class)) {
+            $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+                'sonata.core.twig.status_extension',
+                'addStatusService',
+                [new Reference('sonata.status.renderer')]
+            );
+        } else {
+            $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+                'sonata.core.twig.status_runtime',
+                'addStatusService',
+                [new Reference('sonata.status.renderer')]
+            );
+        }
     }
 }

--- a/tests/SonataCoreBundleTest.php
+++ b/tests/SonataCoreBundleTest.php
@@ -13,6 +13,7 @@ namespace Sonata\CoreBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\DependencyInjection\Compiler\AdapterCompilerPass;
+use Sonata\CoreBundle\DependencyInjection\Compiler\FlashMessageCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\FormFactoryCompilerPass;
 use Sonata\CoreBundle\DependencyInjection\Compiler\StatusRendererCompilerPass;
 use Sonata\CoreBundle\Form\FormHelper;
@@ -80,6 +81,10 @@ final class SonataCoreBundleTest extends TestCase
             ->method('addCompilerPass')
             ->will($this->returnCallback(function (CompilerPassInterface $pass) {
                 if ($pass instanceof StatusRendererCompilerPass) {
+                    return;
+                }
+
+                if ($pass instanceof FlashMessageCompilerPass) {
                     return;
                 }
 

--- a/tests/Twig/Extension/StatusExtensionTest.php
+++ b/tests/Twig/Extension/StatusExtensionTest.php
@@ -14,7 +14,6 @@ namespace Sonata\CoreBundle\Tests\Twig\Extension;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
 use Sonata\CoreBundle\Twig\Extension\StatusExtension;
-use Sonata\CoreBundle\Twig\Extension\StatusRuntime;
 
 class StatusExtensionTest extends TestCase
 {
@@ -32,9 +31,12 @@ class StatusExtensionTest extends TestCase
         $this->assertContainsOnlyInstancesOf('Twig_SimpleFilter', $filters);
     }
 
+    /**
+     * @group legacy
+     */
     public function testStatusClassDefaultValue()
     {
-        $extension = new StatusRuntime();
+        $extension = new StatusExtension();
         $statusService = $this->getMockBuilder(StatusClassRendererInterface::class)
             ->getMock();
         $statusService->expects($this->once())

--- a/tests/Twig/Extension/StatusRuntimeTest.php
+++ b/tests/Twig/Extension/StatusRuntimeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\CoreBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Sonata\CoreBundle\Twig\Extension\StatusRuntime;
+
+class StatusRuntimeTest extends TestCase
+{
+    public function testStatusClassDefaultValue()
+    {
+        $runtime = new StatusRuntime();
+        $statusService = $this->getMockBuilder(StatusClassRendererInterface::class)
+            ->getMock();
+        $statusService->expects($this->once())
+            ->method('handlesObject')
+            ->will($this->returnValue(false));
+
+        $runtime->addStatusService($statusService);
+        $this->assertSame('test-value', $runtime->statusClass(new \stdClass(), 'getStatus', 'test-value'));
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is a fix for a bug in this branch.

Closes https://github.com/sonata-project/SonataCoreBundle/issues/553

## Changelog

```markdown
### Fixed
- Fix compatibility with Symfony 2.8 regarding Twig runtimes
```

## To do
    
- [x] Add/update the tests

## Subject

This PR fixes an unnoticed issue with Symfony 2.8 which does not have a RuntimeLoader, by relying on the deprecated behavior.