### PR TITLE
Handle null values in BooleanTypeToBooleanTransformer

### DIFF
--- a/src/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
+++ b/src/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
@@ -20,17 +20,21 @@ class BooleanTypeToBooleanTransformer implements DataTransformerInterface
     {
         if (true === $value or BooleanType::TYPE_YES === (int) $value) {
             return BooleanType::TYPE_YES;
+        } elseif (false === $value or BooleanType::TYPE_NO === (int) $value) {
+            return BooleanType::TYPE_NO;
         }
 
-        return BooleanType::TYPE_NO;
+        return null;
     }
 
     public function reverseTransform($value)
     {
         if (BooleanType::TYPE_YES === $value) {
             return true;
+        } elseif (BooleanType::TYPE_NO === $value) {
+            return false;
         }
 
-        return false;
+        return null;
     }
 }

--- a/tests/Form/DataTransformer/BooleanTypeToBooleanTransformerTest.php
+++ b/tests/Form/DataTransformer/BooleanTypeToBooleanTransformerTest.php
@@ -32,8 +32,10 @@ class BooleanTypeToBooleanTransformerTest extends TestCase
         $transformer = new BooleanTypeToBooleanTransformer();
         $this->assertTrue($transformer->reverseTransform(BooleanType::TYPE_YES));
         $this->assertTrue($transformer->reverseTransform(1));
-        $this->assertFalse($transformer->reverseTransform('asd'));
         $this->assertFalse($transformer->reverseTransform(BooleanType::TYPE_NO));
+        $this->assertFalse($transformer->reverseTransform(2));
+        $this->assertNull($transformer->reverseTransform(null));
+        $this->assertNull($transformer->reverseTransform('asd'));
     }
 
     public function getReverseTransformData()
@@ -41,11 +43,10 @@ class BooleanTypeToBooleanTransformerTest extends TestCase
         return [
             [true, BooleanType::TYPE_YES],
             [false, BooleanType::TYPE_NO],
-            ['wrong', BooleanType::TYPE_NO],
+            ['wrong', null],
             ['1', BooleanType::TYPE_YES],
             ['2', BooleanType::TYPE_NO],
-
-            ['3', BooleanType::TYPE_NO], // default value is false ...
+            ['3', null], // default value is null ...
         ];
     }
 }


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

## Changelog

```markdown
### Fixed
- Handle null values in BooleanTypeToBooleanTransformer
```
## Subject

Currently the `BooleanTypeToBooleanTransformer` will return false if the value is null, which force the `No` option to be selected. 
