### PR TITLE
Deprecated old classes

### DIFF
--- a/src/Command/SonataDumpDoctrineMetaCommand.php
+++ b/src/Command/SonataDumpDoctrineMetaCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Return useful data on the database schema.
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
 class SonataDumpDoctrineMetaCommand extends ContainerAwareCommand
 {
@@ -62,6 +64,11 @@ class SonataDumpDoctrineMetaCommand extends ContainerAwareCommand
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(
+            'The '.__CLASS__.' class is deprecated since version 3.x and will be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         $output->writeln('Initialising Doctrine metadata.');
         $manager = $this->getContainer()->get('doctrine')->getManager();
         $metadata = $manager->getMetadataFactory()->getAllMetadata();

--- a/src/Exception/InvalidParameterException.php
+++ b/src/Exception/InvalidParameterException.php
@@ -11,6 +11,14 @@
 
 namespace Sonata\CoreBundle\Exception;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\InvalidParameterException class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since 3.x, to be removed in 4.0.
+ */
 class InvalidParameterException extends \RuntimeException
 {
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `SonataDumpDoctrineMetaCommand`
- Deprecated `InvalidParameterException`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject
This classes are unused / located in the wrong bundle.

Refs https://github.com/sonata-project/dev-kit/issues/348
