### PR TITLE
Deprecated doctrine classes

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -14,6 +14,20 @@ A runtime has been introduced to lazy-load some extensions dependencies:
 
 Instead, use the associated runtimes: `FlashMessageRuntime` and `StatusRuntime`.
 
+### Doctrine deprecations
+
+All doctrine classes have been deprecated and were moved to `sonata-project/doctrine-extensions`:
+ - `Model/Adapter/AdapterChain`
+ - `Model/Adapter/AdapterInterface`
+ - `Model/Adapter/DoctrineORMAdapter`
+ - `Model/Adapter/DoctrinePHPCRAdapter`
+ - `Model/BaseDocumentManager`
+ - `Model/BaseEntityManager`
+ - `Model/BaseManager`
+ - `Model/BasePHPCRManager`
+ - `Model/ManagerInterface`
+ - `Model/PageableManagerInterface`
+
 UPGRADE FROM 3.6 to 3.7
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^5.6 || ^7.0",
         "cocur/slugify": "^1.4 || ^2.0 || ^3.0",
         "sonata-project/datagrid-bundle": "^2.0",
+        "sonata-project/doctrine-extensions": "^1.1",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",

--- a/src/Model/Adapter/AdapterChain.php
+++ b/src/Model/Adapter/AdapterChain.php
@@ -11,34 +11,14 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-class AdapterChain implements AdapterInterface
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since 3.x, to be removed in 4.0.
+ */
+class AdapterChain extends \Sonata\Doctrine\Adapter\AdapterChain implements AdapterInterface
 {
-    protected $adapters = [];
-
-    public function addAdapter(AdapterInterface $adapter)
-    {
-        $this->adapters[] = $adapter;
-    }
-
-    public function getNormalizedIdentifier($model)
-    {
-        foreach ($this->adapters as $adapter) {
-            $identifier = $adapter->getNormalizedIdentifier($model);
-
-            if ($identifier) {
-                return $identifier;
-            }
-        }
-    }
-
-    public function getUrlsafeIdentifier($model)
-    {
-        foreach ($this->adapters as $adapter) {
-            $safeIdentifier = $adapter->getUrlsafeIdentifier($model);
-
-            if ($safeIdentifier) {
-                return $safeIdentifier;
-            }
-        }
-    }
 }

--- a/src/Model/Adapter/AdapterChain.php
+++ b/src/Model/Adapter/AdapterChain.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model\Adapter;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Adapter\AdapterChain instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/Adapter/AdapterInterface.php
+++ b/src/Model/Adapter/AdapterInterface.php
@@ -11,28 +11,14 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-interface AdapterInterface
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since 3.x, to be removed in 4.0.
+ */
+interface AdapterInterface extends \Sonata\Doctrine\Adapter\AdapterInterface
 {
-    const ID_SEPARATOR = '~';
-
-    /**
-     * Get the identifiers for this model class as a string.
-     *
-     * @param object $model
-     *
-     * @return string a string representation of the identifiers for this instance
-     */
-    public function getNormalizedIdentifier($model);
-
-    /**
-     * Get the identifiers as a string that is save to use in an url.
-     *
-     * This is similar to getNormalizedIdentifier but guarantees an id that can
-     * be used in an URL.
-     *
-     * @param object $model
-     *
-     * @return string string representation of the id that is save to use in an url
-     */
-    public function getUrlsafeIdentifier($model);
 }

--- a/src/Model/Adapter/AdapterInterface.php
+++ b/src/Model/Adapter/AdapterInterface.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model\Adapter;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Adapter\AdapterInterface instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/Adapter/DoctrineORMAdapter.php
+++ b/src/Model/Adapter/DoctrineORMAdapter.php
@@ -11,58 +11,16 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\EntityManagerInterface;
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * This is a port of the DoctrineORMAdminBundle / ModelManager class.
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-class DoctrineORMAdapter implements AdapterInterface
+class DoctrineORMAdapter extends \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter implements AdapterInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @param ManagerRegistry $registry
-     */
-    public function __construct(ManagerRegistry $registry)
-    {
-        $this->registry = $registry;
-    }
-
-    public function getNormalizedIdentifier($entity)
-    {
-        if (is_scalar($entity)) {
-            throw new \RuntimeException('Invalid argument, object or null required');
-        }
-
-        if (!$entity) {
-            return;
-        }
-
-        $manager = $this->registry->getManagerForClass(\get_class($entity));
-
-        if (!$manager instanceof EntityManagerInterface) {
-            return;
-        }
-
-        if (!$manager->getUnitOfWork()->isInIdentityMap($entity)) {
-            return;
-        }
-
-        return implode(self::ID_SEPARATOR, $manager->getUnitOfWork()->getEntityIdentifier($entity));
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * The ORM implementation does nothing special but you still should use
-     * this method when using the id in a URL to allow for future improvements.
-     */
-    public function getUrlsafeIdentifier($entity)
-    {
-        return $this->getNormalizedIdentifier($entity);
-    }
 }

--- a/src/Model/Adapter/DoctrineORMAdapter.php
+++ b/src/Model/Adapter/DoctrineORMAdapter.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model\Adapter;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/Adapter/DoctrinePHPCRAdapter.php
+++ b/src/Model/Adapter/DoctrinePHPCRAdapter.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model\Adapter;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/Adapter/DoctrinePHPCRAdapter.php
+++ b/src/Model/Adapter/DoctrinePHPCRAdapter.php
@@ -11,65 +11,16 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ODM\PHPCR\DocumentManager;
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * This is a port of the DoctrineORMAdminBundle / ModelManager class.
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-class DoctrinePHPCRAdapter implements AdapterInterface
+class DoctrinePHPCRAdapter extends \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter implements AdapterInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @param ManagerRegistry $registry
-     */
-    public function __construct(ManagerRegistry $registry)
-    {
-        $this->registry = $registry;
-    }
-
-    public function getNormalizedIdentifier($document)
-    {
-        if (is_scalar($document)) {
-            throw new \RuntimeException('Invalid argument, object or null required');
-        }
-
-        if (!$document) {
-            return;
-        }
-
-        $manager = $this->registry->getManagerForClass($document);
-
-        if (!$manager instanceof DocumentManager) {
-            return;
-        }
-
-        if (!$manager->contains($document)) {
-            return;
-        }
-
-        $class = $manager->getClassMetadata(\get_class($document));
-
-        return $class->getIdentifierValue($document);
-    }
-
-    /**
-     * Currently only the leading slash is removed.
-     *
-     * TODO: do we also have to encode certain characters like spaces or does that happen automatically?
-     *
-     * {@inheritdoc}
-     */
-    public function getUrlsafeIdentifier($document)
-    {
-        $id = $this->getNormalizedIdentifier($document);
-
-        if (null !== $id) {
-            return substr($id, 1);
-        }
-    }
 }

--- a/src/Model/BaseDocumentManager.php
+++ b/src/Model/BaseDocumentManager.php
@@ -11,37 +11,16 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
+@trigger_error(
+    'The '.__NAMESPACE__.'\BaseDocumentManager class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-abstract class BaseDocumentManager extends BaseManager
+abstract class BaseDocumentManager extends \Sonata\Doctrine\Document\BaseDocumentManager implements ManagerInterface
 {
-    /**
-     * Make sure the code is compatible with legacy code.
-     *
-     * @return mixed
-     */
-    public function __get($name)
-    {
-        if ('dm' === $name) {
-            return $this->getObjectManager();
-        }
-
-        throw new \RuntimeException(sprintf('The property %s does not exists', $name));
-    }
-
-    public function getConnection()
-    {
-        return $this->getObjectManager()->getConnection();
-    }
-
-    /**
-     * @return DocumentManager
-     */
-    public function getDocumentManager()
-    {
-        return $this->getObjectManager();
-    }
 }

--- a/src/Model/BaseDocumentManager.php
+++ b/src/Model/BaseDocumentManager.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\BaseDocumentManager class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\BaseDocumentManager class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Document\BaseDocumentManager instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/BaseEntityManager.php
+++ b/src/Model/BaseEntityManager.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\BaseEntityManager class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\BaseEntityManager class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Entity\BaseEntityManager instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/BaseEntityManager.php
+++ b/src/Model/BaseEntityManager.php
@@ -11,37 +11,16 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+@trigger_error(
+    'The '.__NAMESPACE__.'\BaseEntityManager class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-abstract class BaseEntityManager extends BaseManager
+abstract class BaseEntityManager extends \Sonata\Doctrine\Entity\BaseEntityManager implements ManagerInterface
 {
-    /**
-     * Make sure the code is compatible with legacy code.
-     *
-     * @return mixed
-     */
-    public function __get($name)
-    {
-        if ('em' === $name) {
-            return $this->getObjectManager();
-        }
-
-        throw new \RuntimeException(sprintf('The property %s does not exists', $name));
-    }
-
-    public function getConnection()
-    {
-        return $this->getEntityManager()->getConnection();
-    }
-
-    /**
-     * @return EntityManager
-     */
-    public function getEntityManager()
-    {
-        return $this->getObjectManager();
-    }
 }

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -11,132 +11,16 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
+@trigger_error(
+    'The '.__NAMESPACE__.'\BaseManager class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-abstract class BaseManager implements ManagerInterface
+abstract class BaseManager extends \Sonata\Doctrine\Model\BaseManager implements ManagerInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @var string
-     */
-    protected $class;
-
-    /**
-     * @param string          $class
-     * @param ManagerRegistry $registry
-     */
-    public function __construct($class, ManagerRegistry $registry)
-    {
-        $this->registry = $registry;
-        $this->class = $class;
-    }
-
-    /**
-     * @return ObjectManager
-     */
-    public function getObjectManager()
-    {
-        $manager = $this->registry->getManagerForClass($this->class);
-
-        if (!$manager) {
-            throw new \RuntimeException(sprintf(
-                'Unable to find the mapping information for the class %s.'
-                .' Please check the `auto_mapping` option'
-                .' (http://symfony.com/doc/current/reference/configuration/doctrine.html#configuration-overview)'
-                .' or add the bundle to the `mappings` section in the doctrine configuration.',
-                $this->class
-            ));
-        }
-
-        return $manager;
-    }
-
-    public function getClass()
-    {
-        return $this->class;
-    }
-
-    public function findAll()
-    {
-        return $this->getRepository()->findAll();
-    }
-
-    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
-    {
-        return $this->getRepository()->findBy($criteria, $orderBy, $limit, $offset);
-    }
-
-    public function findOneBy(array $criteria, array $orderBy = null)
-    {
-        return $this->getRepository()->findOneBy($criteria, $orderBy);
-    }
-
-    public function find($id)
-    {
-        return $this->getRepository()->find($id);
-    }
-
-    public function create()
-    {
-        return new $this->class();
-    }
-
-    public function save($entity, $andFlush = true)
-    {
-        $this->checkObject($entity);
-
-        $this->getObjectManager()->persist($entity);
-
-        if ($andFlush) {
-            $this->getObjectManager()->flush();
-        }
-    }
-
-    public function delete($entity, $andFlush = true)
-    {
-        $this->checkObject($entity);
-
-        $this->getObjectManager()->remove($entity);
-
-        if ($andFlush) {
-            $this->getObjectManager()->flush();
-        }
-    }
-
-    public function getTableName()
-    {
-        return $this->getObjectManager()->getClassMetadata($this->class)->table['name'];
-    }
-
-    /**
-     * Returns the related Object Repository.
-     *
-     * @return ObjectRepository
-     */
-    protected function getRepository()
-    {
-        return $this->getObjectManager()->getRepository($this->class);
-    }
-
-    /**
-     * @throws \InvalidArgumentException
-     */
-    protected function checkObject($object)
-    {
-        if (!$object instanceof $this->class) {
-            throw new \InvalidArgumentException(sprintf(
-                'Object must be instance of %s, %s given',
-                $this->class, \is_object($object) ? \get_class($object) : \gettype($object)
-            ));
-        }
-    }
 }

--- a/src/Model/BaseManager.php
+++ b/src/Model/BaseManager.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\BaseManager class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\BaseManager class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Model\BaseManager instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/BasePHPCRManager.php
+++ b/src/Model/BasePHPCRManager.php
@@ -11,49 +11,14 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\Common\Persistence\ObjectManager;
+@trigger_error(
+    'The '.__NAMESPACE__.'\BasePHPCRManager class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
-abstract class BasePHPCRManager extends BaseManager
+/**
+ * @deprecated since 3.x, to be removed in 4.0.
+ */
+abstract class BasePHPCRManager extends \Sonata\Doctrine\Document\BasePHPCRManager implements ManagerInterface
 {
-    /**
-     * Make sure the code is compatible with legacy code.
-     *
-     * @return mixed
-     */
-    public function __get($name)
-    {
-        if ('dm' === $name) {
-            return $this->getObjectManager();
-        }
-
-        throw new \RuntimeException(sprintf('The property %s does not exists', $name));
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \LogicException Each call
-     */
-    public function getConnection()
-    {
-        throw new \LogicException('PHPCR does not use a database connection.');
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \LogicException Each call
-     */
-    public function getTableName()
-    {
-        throw new \LogicException('PHPCR does not use a reference name for a list of data.');
-    }
-
-    /**
-     * @return ObjectManager
-     */
-    public function getDocumentManager()
-    {
-        return $this->getObjectManager();
-    }
 }

--- a/src/Model/BasePHPCRManager.php
+++ b/src/Model/BasePHPCRManager.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\BasePHPCRManager class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\BasePHPCRManager class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Document\BasePHPCRManager instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/ManagerInterface.php
+++ b/src/Model/ManagerInterface.php
@@ -11,87 +11,16 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Doctrine\DBAL\Connection;
+@trigger_error(
+    'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-interface ManagerInterface
+interface ManagerInterface extends \Sonata\Doctrine\Model\ManagerInterface
 {
-    /**
-     * Return the Entity class name.
-     *
-     * @return string
-     */
-    public function getClass();
-
-    /**
-     * Find all entities in the repository.
-     *
-     * @return array
-     */
-    public function findAll();
-
-    /**
-     * Find entities by a set of criteria.
-     *
-     * @param int|null $limit
-     * @param int|null $offset
-     *
-     * @return array
-     */
-    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null);
-
-    /**
-     * Find a single entity by a set of criteria.
-     *
-     * @return object|null
-     */
-    public function findOneBy(array $criteria, array $orderBy = null);
-
-    /**
-     * Finds an entity by its primary key / identifier.
-     *
-     * @param mixed $id The identifier
-     *
-     * @return object
-     */
-    public function find($id);
-
-    /**
-     * Create an empty Entity instance.
-     *
-     * @return object
-     */
-    public function create();
-
-    /**
-     * Save an Entity.
-     *
-     * @param object $entity   The Entity to save
-     * @param bool   $andFlush Flush the EntityManager after saving the object?
-     */
-    public function save($entity, $andFlush = true);
-
-    /**
-     * Delete an Entity.
-     *
-     * @param object $entity   The Entity to delete
-     * @param bool   $andFlush Flush the EntityManager after deleting the object?
-     */
-    public function delete($entity, $andFlush = true);
-
-    /**
-     * Get the related table name.
-     *
-     * @return string
-     */
-    public function getTableName();
-
-    /**
-     * Get the DB driver connection.
-     *
-     * @return Connection
-     */
-    public function getConnection();
 }

--- a/src/Model/ManagerInterface.php
+++ b/src/Model/ManagerInterface.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Model\ManagerInterface instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -11,18 +11,16 @@
 
 namespace Sonata\CoreBundle\Model;
 
-use Sonata\DatagridBundle\Pager\PagerInterface;
+@trigger_error(
+    'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Raphaël Benitte <benitteraphael@gmail.com>
+ *
+ * @deprecated since 3.x, to be removed in 4.0.
  */
-interface PageableManagerInterface
+interface PageableManagerInterface extends \Sonata\Doctrine\Model\PageableManagerInterface
 {
-    /**
-     * @param int $page
-     * @param int $limit
-     *
-     * @return PagerInterface
-     */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = []);
 }

--- a/src/Model/PageableManagerInterface.php
+++ b/src/Model/PageableManagerInterface.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Model;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\DatagridBundle\Pager\PageableInterface instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Resources/config/model_adapter.xml
+++ b/src/Resources/config/model_adapter.xml
@@ -3,10 +3,14 @@
     <services>
         <service id="sonata.core.model.adapter.doctrine_orm" class="Sonata\CoreBundle\Model\Adapter\DoctrineORMAdapter" public="false">
             <argument type="service" id="doctrine" on-invalid="ignore"/>
+            <deprecated>The "%service_id%" service is deprecated since 3.x and will be removed in 4.0.</deprecated>
         </service>
         <service id="sonata.core.model.adapter.doctrine_phpcr" class="Sonata\CoreBundle\Model\Adapter\DoctrinePHPCRAdapter" public="false">
             <argument type="service" id="doctrine_phpcr" on-invalid="ignore"/>
+            <deprecated>The "%service_id%" service is deprecated since 3.x and will be removed in 4.0.</deprecated>
         </service>
-        <service id="sonata.core.model.adapter.chain" class="Sonata\CoreBundle\Model\Adapter\AdapterChain" public="true"/>
+        <service id="sonata.core.model.adapter.chain" class="Sonata\CoreBundle\Model\Adapter\AdapterChain" public="true">
+            <deprecated>The "%service_id%" service is deprecated since 3.x and will be removed in 4.0.</deprecated>
+        </service>
     </services>
 </container>

--- a/src/Test/EntityManagerMockFactory.php
+++ b/src/Test/EntityManagerMockFactory.php
@@ -12,7 +12,8 @@
 namespace Sonata\CoreBundle\Test;
 
 @trigger_error(
-    'The '.__NAMESPACE__.'\EntityManagerMockFactory class is deprecated since version 3.x and will be removed in 4.0.',
+    'The '.__NAMESPACE__.'\EntityManagerMockFactory class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\Doctrine\Test\EntityManagerMockFactory instead.',
     E_USER_DEPRECATED
 );
 

--- a/src/Test/EntityManagerMockFactory.php
+++ b/src/Test/EntityManagerMockFactory.php
@@ -11,53 +11,14 @@
 
 namespace Sonata\CoreBundle\Test;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Version;
-use PHPUnit\Framework\TestCase;
+@trigger_error(
+    'The '.__NAMESPACE__.'\EntityManagerMockFactory class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
 
-class EntityManagerMockFactory
+/**
+ * @deprecated since 3.x, to be removed in 4.0.
+ */
+class EntityManagerMockFactory extends \Sonata\Doctrine\Test\EntityManagerMockFactory
 {
-    /**
-     * @return EntityManagerInterface
-     */
-    public static function create(TestCase $test, \Closure $qbCallback, $fields)
-    {
-        $query = $test->getMockBuilder(AbstractQuery::class)
-            ->disableOriginalConstructor()->getMock();
-        $query->expects($test->any())->method('execute')->will($test->returnValue(true));
-
-        if (Version::compare('2.5.0') < 1) {
-            $entityManager = $test->getMockBuilder(EntityManagerInterface::class)->getMock();
-            $qb = $test->getMockBuilder(QueryBuilder::class)->setConstructorArgs([$entityManager])->getMock();
-        } else {
-            $qb = $test->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
-        }
-
-        $qb->expects($test->any())->method('select')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('getQuery')->will($test->returnValue($query));
-        $qb->expects($test->any())->method('where')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('orderBy')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('andWhere')->will($test->returnValue($qb));
-        $qb->expects($test->any())->method('leftJoin')->will($test->returnValue($qb));
-
-        $qbCallback($qb);
-
-        $repository = $test->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
-        $repository->expects($test->any())->method('createQueryBuilder')->will($test->returnValue($qb));
-
-        $metadata = $test->getMockBuilder(ClassMetadata::class)->getMock();
-        $metadata->expects($test->any())->method('getFieldNames')->will($test->returnValue($fields));
-        $metadata->expects($test->any())->method('getName')->will($test->returnValue('className'));
-
-        $em = $test->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
-        $em->expects($test->any())->method('getRepository')->will($test->returnValue($repository));
-        $em->expects($test->any())->method('getClassMetadata')->will($test->returnValue($metadata));
-
-        return $em;
-    }
 }

--- a/tests/Fixtures/Entity/EntityManager.php
+++ b/tests/Fixtures/Entity/EntityManager.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sonata\CoreBundle\Tests\Fixtures\Entity;
+
+use Sonata\CoreBundle\Model\BaseEntityManager;
+
+class EntityManager extends BaseEntityManager
+{
+}

--- a/tests/Fixtures/Model/DocumentManager.php
+++ b/tests/Fixtures/Model/DocumentManager.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Sonata\CoreBundle\Tests\Fixtures\Model;
+
+use Sonata\CoreBundle\Model\BaseDocumentManager;
+
+/**
+ * @group legacy
+ */
+class DocumentManager extends BaseDocumentManager
+{
+}

--- a/tests/Fixtures/Model/Manager.php
+++ b/tests/Fixtures/Model/Manager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sonata\CoreBundle\Tests\Fixtures\Model;
+
+use Sonata\CoreBundle\Model\BaseManager;
+
+class Manager extends BaseManager
+{
+    /**
+     * Get the DB driver connection.
+     *
+     * @return Connection
+     */
+    public function getConnection()
+    {
+    }
+
+    /**
+     * @param $object
+     */
+    public function publicCheckObject($object)
+    {
+        return $this->checkObject($object);
+    }
+}

--- a/tests/Model/Adapter/AdapterChainTest.php
+++ b/tests/Model/Adapter/AdapterChainTest.php
@@ -17,6 +17,9 @@ use Sonata\CoreBundle\Model\Adapter\AdapterInterface;
 
 class AdapterChainTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testEmptyAdapter()
     {
         $adapter = new AdapterChain();
@@ -25,6 +28,9 @@ class AdapterChainTest extends TestCase
         $this->assertNull($adapter->getUrlsafeIdentifier(new \stdClass()));
     }
 
+    /**
+     * @group legacy
+     */
     public function testUrlSafeIdentifier()
     {
         $adapter = new AdapterChain();
@@ -39,6 +45,9 @@ class AdapterChainTest extends TestCase
         $this->assertSame('voila', $adapter->getUrlsafeIdentifier(new \stdClass()));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifier()
     {
         $adapter = new AdapterChain();

--- a/tests/Model/Adapter/DoctrineORMAdapterTest.php
+++ b/tests/Model/Adapter/DoctrineORMAdapterTest.php
@@ -26,6 +26,9 @@ class DoctrineORMAdapterTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithScalar()
     {
         $this->expectException(\RuntimeException::class);
@@ -36,6 +39,9 @@ class DoctrineORMAdapterTest extends TestCase
         $adapter->getNormalizedIdentifier(1);
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNull()
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -44,6 +50,9 @@ class DoctrineORMAdapterTest extends TestCase
         $this->assertNull($adapter->getNormalizedIdentifier(null));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNoManager()
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -54,6 +63,9 @@ class DoctrineORMAdapterTest extends TestCase
         $this->assertNull($adapter->getNormalizedIdentifier(new \stdClass()));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNotManaged()
     {
         $unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
@@ -72,6 +84,8 @@ class DoctrineORMAdapterTest extends TestCase
 
     /**
      * @dataProvider getFixtures
+     *
+     * @group legacy
      */
     public function testNormalizedIdentifierWithValidObject($data, $expected)
     {

--- a/tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
+++ b/tests/Model/Adapter/DoctrinePHPCRAdapterTest.php
@@ -32,6 +32,9 @@ class DoctrinePHPCRAdapterTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithScalar()
     {
         $this->expectException(\RuntimeException::class);
@@ -42,6 +45,9 @@ class DoctrinePHPCRAdapterTest extends TestCase
         $adapter->getNormalizedIdentifier(1);
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNull()
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -50,6 +56,9 @@ class DoctrinePHPCRAdapterTest extends TestCase
         $this->assertNull($adapter->getNormalizedIdentifier(null));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNoManager()
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -60,6 +69,9 @@ class DoctrinePHPCRAdapterTest extends TestCase
         $this->assertNull($adapter->getNormalizedIdentifier(new \stdClass()));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNormalizedIdentifierWithNotManaged()
     {
         $manager = $this->getMockBuilder(DocumentManager::class)->disableOriginalConstructor()->getMock();
@@ -75,6 +87,8 @@ class DoctrinePHPCRAdapterTest extends TestCase
 
     /**
      * @dataProvider getFixtures
+     *
+     * @group legacy
      */
     public function testNormalizedIdentifierWithValidObject($data, $expected)
     {

--- a/tests/Model/BaseDocumentManagerTest.php
+++ b/tests/Model/BaseDocumentManagerTest.php
@@ -13,11 +13,7 @@ namespace Sonata\CoreBundle\Tests\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Model\BaseDocumentManager;
-
-class DocumentManager extends BaseDocumentManager
-{
-}
+use Sonata\CoreBundle\Tests\Fixtures\Model\DocumentManager;
 
 class BaseDocumentManagerTest extends TestCase
 {

--- a/tests/Model/BaseDocumentManagerTest.php
+++ b/tests/Model/BaseDocumentManagerTest.php
@@ -30,6 +30,9 @@ class BaseDocumentManagerTest extends TestCase
         return $manager;
     }
 
+    /**
+     * @group legacy
+     */
     public function test()
     {
         $this->assertSame('classname', $this->getManager()->getClass());

--- a/tests/Model/BaseEntityManagerTest.php
+++ b/tests/Model/BaseEntityManagerTest.php
@@ -14,11 +14,7 @@ namespace Sonata\CoreBundle\Tests\Entity;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Model\BaseEntityManager;
-
-class EntityManager extends BaseEntityManager
-{
-}
+use Sonata\CoreBundle\Tests\Fixtures\Entity\EntityManager;
 
 class BaseEntityManagerTest extends TestCase
 {

--- a/tests/Model/BaseEntityManagerTest.php
+++ b/tests/Model/BaseEntityManagerTest.php
@@ -31,11 +31,17 @@ class BaseEntityManagerTest extends TestCase
         return $manager;
     }
 
+    /**
+     * @group legacy
+     */
     public function test()
     {
         $this->assertSame('classname', $this->getManager()->getClass());
     }
 
+    /**
+     * @group legacy
+     */
     public function testException()
     {
         $this->expectException(\RuntimeException::class);
@@ -44,6 +50,9 @@ class BaseEntityManagerTest extends TestCase
         $this->getManager()->exception;
     }
 
+    /**
+     * @group legacy
+     */
     public function testExceptionOnNonMappedEntity()
     {
         $this->expectException(\RuntimeException::class);
@@ -56,6 +65,9 @@ class BaseEntityManagerTest extends TestCase
         $manager->getObjectManager();
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetEntityManager()
     {
         $objectManager = $this->createMock(ObjectManager::class);

--- a/tests/Model/BaseManagerTest.php
+++ b/tests/Model/BaseManagerTest.php
@@ -12,29 +12,8 @@
 namespace Sonata\CoreBundle\Tests\Model;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
-use Sonata\CoreBundle\Model\BaseManager;
-
-class ManagerTest extends BaseManager
-{
-    /**
-     * Get the DB driver connection.
-     *
-     * @return Connection
-     */
-    public function getConnection()
-    {
-    }
-
-    /**
-     * @param $object
-     */
-    public function publicCheckObject($object)
-    {
-        return $this->checkObject($object);
-    }
-}
+use Sonata\CoreBundle\Tests\Fixtures\Model\Manager;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -49,7 +28,7 @@ class BaseManagerTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Object must be instance of class, DateTime given');
 
-        $manager = new ManagerTest('class', $this->createMock(ManagerRegistry::class));
+        $manager = new Manager('class', $this->createMock(ManagerRegistry::class));
 
         $manager->publicCheckObject(new \DateTime());
     }

--- a/tests/Model/BaseManagerTest.php
+++ b/tests/Model/BaseManagerTest.php
@@ -41,6 +41,9 @@ class ManagerTest extends BaseManager
  */
 class BaseManagerTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testCheckObject()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
 - Deprecated `Model/Adapter/AdapterChain` 
 - Deprecated `Model/Adapter/AdapterInterface`
 - Deprecated `Model/Adapter/DoctrineORMAdapter`
 - Deprecated `Model/Adapter/DoctrinePHPCRAdapter`
 - Deprecated `Model/BaseDocumentManager`
 - Deprecated `Model/BaseEntityManager`
 - Deprecated `Model/BaseManager`
 - Deprecated `Model/BasePHPCRManager`
 - Deprecated `Model/ManagerInterface`
 - Deprecated `Model/PageableManagerInterface`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

Finally, we can deprecate (and remove) some classes.
