### PR TITLE
Strictness

### DIFF
--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -28,7 +28,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 abstract class BasePickerType extends AbstractType
 {
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface|null
      */
     protected $translator;
 

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -80,7 +80,9 @@ abstract class BasePickerType extends AbstractType
             if (\is_int($format)) {
                 $timeFormat = \IntlDateFormatter::NONE;
                 if ($options['dp_pick_time']) {
-                    $timeFormat = $options['dp_use_seconds'] ? DateTimeType::DEFAULT_TIME_FORMAT : \IntlDateFormatter::SHORT;
+                    $timeFormat = $options['dp_use_seconds'] ?
+                        DateTimeType::DEFAULT_TIME_FORMAT :
+                        \IntlDateFormatter::SHORT;
                 }
                 $intlDateFormatter = new \IntlDateFormatter(
                     $this->locale,

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -89,8 +89,7 @@ abstract class BasePickerType extends AbstractType
                     $format,
                     $timeFormat,
                     null,
-                    \IntlDateFormatter::GREGORIAN,
-                    null
+                    \IntlDateFormatter::GREGORIAN
                 );
 
                 return $intlDateFormatter->getPattern();


### PR DESCRIPTION
I am targeting this branch, because this is BC.


Refs #586 

## Subject

The build in #586 is red because of a "strict types" declaration that has issues with a `null` argument to `\IntlDateFormatter`. These changes should fix it, along with other issues in that file. 
