### PR TITLE
Fix fatal error related to missing retrurn statement in FlashMessageExtension

### DIFF
--- a/src/CoreBundle/Twig/Extension/FlashMessageExtension.php
+++ b/src/CoreBundle/Twig/Extension/FlashMessageExtension.php
@@ -57,7 +57,7 @@ class FlashMessageExtension extends \Sonata\Twig\Extension\FlashMessageExtension
             ];
         }
 
-        parent::getFunctions();
+        return parent::getFunctions();
     }
 
     /**


### PR DESCRIPTION
## Subject

I am targeting this branch, because it fixes a fatal error.

## Changelog

```markdown
### Fixed
 - Fixed a missing return statement in FlashMessageExtension
```