### PR TITLE
Fixed Invalid argument supplied for foreach

### DIFF
--- a/src/CoreBundle/Twig/Extension/FlashMessageExtension.php
+++ b/src/CoreBundle/Twig/Extension/FlashMessageExtension.php
@@ -57,7 +57,7 @@ class FlashMessageExtension extends \Sonata\Twig\Extension\FlashMessageExtension
             ];
         }
 
-        parent::getFunctions();
+        return parent::getFunctions();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
The FlashMessageExtension function getFunctions does not return the result of parent function causing exception below:
> An exception has been thrown during the compilation of a template (Warning: Invalid argument supplied for foreach()).
As the bundle is used in various bundles in symfony framework, this looks critical.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the issue exists on this branch, it is the latest and supposed to be stable and because the symfony project I'm working on is affected with this version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #602

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Invalid argument supplied for foreach
```