### PR TITLE
Use aliasing instead of inheritance

### DIFF
--- a/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
+++ b/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Component\Status;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Hugo Briand <briand@ekino.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-interface StatusClassRendererInterface extends \Sonata\Twig\Status\StatusClassRendererInterface
-{
-}
+class_alias(
+    '\Sonata\Twig\Status\StatusClassRendererInterface',
+    '\Sonata\CoreBundle\Component\Status\StatusClassRendererInterface'
+);


### PR DESCRIPTION
## Subject

This allows to use both interfaces interchangeably, solving any type
hinting issue. Signatures might even be changed to the new interface
without that being a BC-break as long as this alias exists.

I am targeting this branch, because this is BC.

Fixes #600, Closes #604 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash about `FlashManager` not being an instance of `StatusClassRendererInterface`
```
