### PR TITLE
Fix forms namespace

### DIFF
--- a/src/CoreBundle/Resources/config/date.xml
+++ b/src/CoreBundle/Resources/config/date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.date.moment_format_converter" class="Sonata\CoreBundle\Date\MomentFormatConverter"/>
+        <service id="sonata.core.date.moment_format_converter" class="Sonata\Form\Date\MomentFormatConverter"/>
     </services>
 </container>

--- a/src/CoreBundle/Resources/config/date.xml
+++ b/src/CoreBundle/Resources/config/date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.date.moment_format_converter" class="Sonata\Form\Date\MomentFormatConverter"/>
+        <service id="sonata.core.date.moment_format_converter" class="Sonata\CoreBundle\Date\MomentFormatConverter"/>
     </services>
 </container>

--- a/src/CoreBundle/Resources/config/form_types.xml
+++ b/src/CoreBundle/Resources/config/form_types.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.form.type.array" class="Sonata\CoreBundle\Form\Type\ImmutableArrayType" public="true">
+        <service id="sonata.core.form.type.array" class="Sonata\Form\Type\ImmutableArrayType" public="true">
             <tag name="form.type" alias="sonata_type_immutable_array"/>
         </service>
-        <service id="sonata.core.form.type.boolean" class="Sonata\CoreBundle\Form\Type\BooleanType" public="true">
+        <service id="sonata.core.form.type.boolean" class="Sonata\Form\Type\BooleanType" public="true">
             <tag name="form.type" alias="sonata_type_boolean"/>
         </service>
-        <service id="sonata.core.form.type.collection" class="Sonata\CoreBundle\Form\Type\CollectionType" public="true">
+        <service id="sonata.core.form.type.collection" class="Sonata\Form\Type\CollectionType" public="true">
             <tag name="form.type" alias="sonata_type_collection"/>
         </service>
         <service id="sonata.core.form.type.translatable_choice" class="Sonata\CoreBundle\Form\Type\TranslatableChoiceType" public="true">
@@ -15,33 +15,33 @@
             <tag name="form.type" alias="sonata_type_translatable_choice"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range" class="Sonata\CoreBundle\Form\Type\DateRangeType" public="true">
+        <service id="sonata.core.form.type.date_range" class="Sonata\Form\Type\DateRangeType" public="true">
             <tag name="form.type" alias="sonata_type_date_range"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range" class="Sonata\CoreBundle\Form\Type\DateTimeRangeType" public="true">
+        <service id="sonata.core.form.type.datetime_range" class="Sonata\Form\Type\DateTimeRangeType" public="true">
             <tag name="form.type" alias="sonata_type_datetime_range"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_picker" class="Sonata\CoreBundle\Form\Type\DatePickerType" public="true">
+        <service id="sonata.core.form.type.date_picker" class="Sonata\Form\Type\DatePickerType" public="true">
             <tag name="form.type" alias="sonata_type_date_picker"/>
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_picker" class="Sonata\CoreBundle\Form\Type\DateTimePickerType" public="true">
+        <service id="sonata.core.form.type.datetime_picker" class="Sonata\Form\Type\DateTimePickerType" public="true">
             <tag name="form.type" alias="sonata_type_datetime_picker"/>
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range_picker" class="Sonata\CoreBundle\Form\Type\DateRangePickerType" public="true">
+        <service id="sonata.core.form.type.date_range_picker" class="Sonata\Form\Type\DateRangePickerType" public="true">
             <tag name="form.type" alias="sonata_type_date_range_picker"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\CoreBundle\Form\Type\DateTimeRangePickerType" public="true">
+        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\Form\Type\DateTimeRangePickerType" public="true">
             <tag name="form.type" alias="sonata_type_datetime_range_picker"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.equal" class="Sonata\CoreBundle\Form\Type\EqualType" public="true">
+        <service id="sonata.core.form.type.equal" class="Sonata\Form\Type\EqualType" public="true">
             <tag name="form.type" alias="sonata_type_equal"/>
             <argument type="service" id="translator"/>
         </service>

--- a/src/CoreBundle/Resources/config/form_types.xml
+++ b/src/CoreBundle/Resources/config/form_types.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.form.type.array" class="Sonata\Form\Type\ImmutableArrayType" public="true">
+        <service id="sonata.core.form.type.array" class="Sonata\CoreBundle\Form\Type\ImmutableArrayType" public="true">
             <tag name="form.type" alias="sonata_type_immutable_array"/>
         </service>
-        <service id="sonata.core.form.type.boolean" class="Sonata\Form\Type\BooleanType" public="true">
+        <service id="sonata.core.form.type.boolean" class="Sonata\CoreBundle\Form\Type\BooleanType" public="true">
             <tag name="form.type" alias="sonata_type_boolean"/>
         </service>
-        <service id="sonata.core.form.type.collection" class="Sonata\Form\Type\CollectionType" public="true">
+        <service id="sonata.core.form.type.collection" class="Sonata\CoreBundle\Form\Type\CollectionType" public="true">
             <tag name="form.type" alias="sonata_type_collection"/>
         </service>
         <service id="sonata.core.form.type.translatable_choice" class="Sonata\CoreBundle\Form\Type\TranslatableChoiceType" public="true">
@@ -15,11 +15,11 @@
             <tag name="form.type" alias="sonata_type_translatable_choice"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range" class="Sonata\Form\Type\DateRangeType" public="true">
+        <service id="sonata.core.form.type.date_range" class="Sonata\CoreBundle\Form\Type\DateRangeType" public="true">
             <tag name="form.type" alias="sonata_type_date_range"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range" class="Sonata\Form\Type\DateTimeRangeType" public="true">
+        <service id="sonata.core.form.type.datetime_range" class="Sonata\CoreBundle\Form\Type\DateTimeRangeType" public="true">
             <tag name="form.type" alias="sonata_type_datetime_range"/>
             <argument type="service" id="translator"/>
         </service>
@@ -33,11 +33,11 @@
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range_picker" class="Sonata\Form\Type\DateRangePickerType" public="true">
+        <service id="sonata.core.form.type.date_range_picker" class="Sonata\CoreBundle\Form\Type\DateRangePickerType" public="true">
             <tag name="form.type" alias="sonata_type_date_range_picker"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\Form\Type\DateTimeRangePickerType" public="true">
+        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\CoreBundle\Form\Type\DateTimeRangePickerType" public="true">
             <tag name="form.type" alias="sonata_type_datetime_range_picker"/>
             <argument type="service" id="translator"/>
         </service>


### PR DESCRIPTION
## Fix forms namespace in form_types.xml

After moving the namespace from `Sonata\CoreBundle\Form` to `Sonata\Form` the form_types.xml and date.xml still pointed to old namespace.

I am targeting this branch, because it is a bug fix.

## Changelog

Fix namespace in form_types.xml and date.xml