### PR TITLE
Apply aliasing over extension wherever we can

### DIFF
--- a/src/CoreBundle/Date/MomentFormatConverter.php
+++ b/src/CoreBundle/Date/MomentFormatConverter.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Date;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class MomentFormatConverter extends \Sonata\Form\Date\MomentFormatConverter
-{
-}
+class_alias(
+    \Sonata\Form\Date\MomentFormatConverter::class,
+    __NAMESPACE__.'\MomentFormatConverter'
+);

--- a/src/CoreBundle/FlashMessage/FlashManager.php
+++ b/src/CoreBundle/FlashMessage/FlashManager.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\FlashMessage;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Vincent Composieux <composieux@ekino.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class FlashManager extends \Sonata\Twig\FlashMessage\FlashManager
-{
-}
+class_alias(
+    \Sonata\Twig\FlashMessage\FlashManager::class,
+    __NAMESPACE__.'\FlashManager'
+);

--- a/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
+++ b/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\DataTransformer;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class BooleanTypeToBooleanTransformer extends \Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer
-{
-}
+class_alias(
+    \Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer::class,
+    __NAMESPACE__.'\BooleanTypeToBooleanTransformer'
+);

--- a/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class BaseDoctrineORMSerializationType extends \Sonata\Form\Type\BaseDoctrineORMSerializationType
-{
-}
+class_alias(
+    \Sonata\Form\Type\BaseDoctrineORMSerializationType::class,
+    __NAMESPACE__.'\BaseDoctrineORMSerializationType'
+);

--- a/src/CoreBundle/Form/Type/BasePickerType.php
+++ b/src/CoreBundle/Form/Type/BasePickerType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-abstract class BasePickerType extends \Sonata\Form\Type\BasePickerType
-{
-}
+class_alias(
+    \Sonata\Form\Type\BasePickerType::class,
+    __NAMESPACE__.'\BasePickerType'
+);

--- a/src/CoreBundle/Form/Type/BaseStatusType.php
+++ b/src/CoreBundle/Form/Type/BaseStatusType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-abstract class BaseStatusType extends \Sonata\Form\Type\BaseStatusType
-{
-}
+class_alias(
+    \Sonata\Form\Type\BaseStatusType::class,
+    __NAMESPACE__.'\BaseStatusType'
+);

--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class BooleanType extends \Sonata\Form\Type\BooleanType
-{
-}
+class_alias(
+    \Sonata\Form\Type\BooleanType::class,
+    __NAMESPACE__.'\BooleanType'
+);

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class CollectionType extends \Sonata\Form\Type\CollectionType
-{
-}
+class_alias(
+    \Sonata\Form\Type\CollectionType::class,
+    __NAMESPACE__.'\CollectionType'
+);

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
-{
-}
+class_alias(
+    \Sonata\Form\Type\DateRangePickerType::class,
+    __NAMESPACE__.'\DateRangePickerType'
+);

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class DateRangeType extends \Sonata\Form\Type\DateRangeType
-{
-}
+class_alias(
+    \Sonata\Form\Type\DateRangeType::class,
+    __NAMESPACE__.'\DateRangeType'
+);

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
-{
-}
+class_alias(
+    \Sonata\Form\Type\DateTimeRangePickerType::class,
+    __NAMESPACE__.'\DateTimeRangePickerType'
+);

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
-{
-}
+class_alias(
+    \Sonata\Form\Type\DateTimeRangeType::class,
+    __NAMESPACE__.'\DateTimeRangeType'
+);

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class EqualType extends \Sonata\Form\Type\EqualType
-{
-}
+class_alias(
+    \Sonata\Form\Type\EqualType::class,
+    __NAMESPACE__.'\EqualType'
+);

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Form\Type;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
-{
-}
+class_alias(
+    \Sonata\Form\Type\ImmutableArrayType::class,
+    __NAMESPACE__.'\ImmutableArrayType'
+);

--- a/src/CoreBundle/Model/Adapter/AdapterChain.php
+++ b/src/CoreBundle/Model/Adapter/AdapterChain.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Model\Adapter;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated since 3.x, to be removed in 4.0.
- */
-class AdapterChain extends \Sonata\Doctrine\Adapter\AdapterChain implements AdapterInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Adapter\AdapterChain::class,
+    __NAMESPACE__.'\AdapterChain'
+);

--- a/src/CoreBundle/Model/Adapter/AdapterInterface.php
+++ b/src/CoreBundle/Model/Adapter/AdapterInterface.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Model\Adapter;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated since 3.x, to be removed in 4.0.
- */
-interface AdapterInterface extends \Sonata\Doctrine\Adapter\AdapterInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Adapter\AdapterInterface::class,
+    __NAMESPACE__.'\AdapterInterface'
+);

--- a/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model\Adapter;
     E_USER_DEPRECATED
 );
 
-/**
- * This is a port of the DoctrineORMAdminBundle / ModelManager class.
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-class DoctrineORMAdapter extends \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter implements AdapterInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter::class,
+    __NAMESPACE__.'\DoctrineORMAdapter'
+);

--- a/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model\Adapter;
     E_USER_DEPRECATED
 );
 
-/**
- * This is a port of the DoctrineORMAdminBundle / ModelManager class.
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-class DoctrinePHPCRAdapter extends \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter implements AdapterInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter::class,
+    __NAMESPACE__.'\DoctrinePHPCRAdapter'
+);

--- a/src/CoreBundle/Model/BaseDocumentManager.php
+++ b/src/CoreBundle/Model/BaseDocumentManager.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Hugo Briand <briand@ekino.com>
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-abstract class BaseDocumentManager extends \Sonata\Doctrine\Document\BaseDocumentManager implements ManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Document\BaseDocumentManager::class,
+    __NAMESPACE__.'\BaseDocumentManager'
+);

--- a/src/CoreBundle/Model/BaseEntityManager.php
+++ b/src/CoreBundle/Model/BaseEntityManager.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Sylvain Deloux <sylvain.deloux@ekino.com>
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-abstract class BaseEntityManager extends \Sonata\Doctrine\Entity\BaseEntityManager implements ManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Entity\BaseEntityManager::class,
+    __NAMESPACE__.'\BaseEntityManager'
+);

--- a/src/CoreBundle/Model/BaseManager.php
+++ b/src/CoreBundle/Model/BaseManager.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Hugo Briand <briand@ekino.com>
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-abstract class BaseManager extends \Sonata\Doctrine\Model\BaseManager implements ManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Model\BaseManager::class,
+    __NAMESPACE__.'\BaseManager'
+);

--- a/src/CoreBundle/Model/BasePHPCRManager.php
+++ b/src/CoreBundle/Model/BasePHPCRManager.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated since 3.x, to be removed in 4.0.
- */
-abstract class BasePHPCRManager extends \Sonata\Doctrine\Document\BasePHPCRManager implements ManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Document\BasePHPCRManager::class,
+    __NAMESPACE__.'\BasePHPCRManager'
+);

--- a/src/CoreBundle/Model/ManagerInterface.php
+++ b/src/CoreBundle/Model/ManagerInterface.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Sylvain Deloux <sylvain.deloux@ekino.com>
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-interface ManagerInterface extends \Sonata\Doctrine\Model\ManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Model\ManagerInterface::class,
+    __NAMESPACE__.'\ManagerInterface'
+);

--- a/src/CoreBundle/Model/PageableManagerInterface.php
+++ b/src/CoreBundle/Model/PageableManagerInterface.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Model;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Raphaël Benitte <benitteraphael@gmail.com>
- *
- * @deprecated since 3.x, to be removed in 4.0.
- */
-interface PageableManagerInterface extends \Sonata\Doctrine\Model\PageableManagerInterface
-{
-}
+class_alias(
+    \Sonata\Doctrine\Model\PageableManagerInterface::class,
+    __NAMESPACE__.'\PageableManagerInterface'
+);

--- a/src/CoreBundle/Serializer/BaseSerializerHandler.php
+++ b/src/CoreBundle/Serializer/BaseSerializerHandler.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Serializer;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-abstract class BaseSerializerHandler extends \Sonata\Serializer\BaseSerializerHandler implements SerializerHandlerInterface
-{
-}
+class_alias(
+    \Sonata\Serializer\BaseSerializerHandler::class,
+    __NAMESPACE__.'\BaseSerializerHandler'
+);

--- a/src/CoreBundle/Serializer/SerializerHandlerInterface.php
+++ b/src/CoreBundle/Serializer/SerializerHandlerInterface.php
@@ -17,13 +17,7 @@ namespace Sonata\CoreBundle\Serializer;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-interface SerializerHandlerInterface extends \Sonata\Serializer\SerializerHandlerInterface
-{
-    /**
-     * @return string
-     */
-    public static function getType();
-}
+class_alias(
+    \Sonata\Serializer\SerializerHandlerInterface::class,
+    __NAMESPACE__.'\SerializerHandlerInterface'
+);

--- a/src/CoreBundle/Test/AbstractWidgetTestCase.php
+++ b/src/CoreBundle/Test/AbstractWidgetTestCase.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Test;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-abstract class AbstractWidgetTestCase extends \Sonata\Form\Test\AbstractWidgetTestCase
-{
-}
+class_alias(
+    \Sonata\Form\Test\AbstractWidgetTestCase::class,
+    __NAMESPACE__.'\AbstractWidgetTestCase'
+);

--- a/src/CoreBundle/Test/EntityManagerMockFactory.php
+++ b/src/CoreBundle/Test/EntityManagerMockFactory.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Test;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated since 3.x, to be removed in 4.0.
- */
-class EntityManagerMockFactory extends \Sonata\Doctrine\Test\EntityManagerMockFactory
-{
-}
+class_alias(
+    \Sonata\Doctrine\Test\EntityManagerMockFactory::class,
+    __NAMESPACE__.'\EntityManagerMockFactory'
+);

--- a/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Twig\Extension;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Marko Kunic <kunicmarko20@gmail.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-final class DeprecatedTemplateExtension extends \Sonata\Twig\Extension\DeprecatedTemplateExtension
-{
-}
+class_alias(
+    \Sonata\Twig\Extension\DeprecatedTemplateExtension::class,
+    __NAMESPACE__.'\DeprecatedTemplateExtension'
+);

--- a/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
+++ b/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
@@ -17,14 +17,7 @@ namespace Sonata\CoreBundle\Twig\Extension;
     E_USER_DEPRECATED
 );
 
-/**
- * This is the Sonata core flash message Twig runtime.
- *
- * @author Vincent Composieux <composieux@ekino.com>
- * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-final class FlashMessageRuntime extends \Sonata\Twig\Extension\FlashMessageRuntime
-{
-}
+class_alias(
+    \Sonata\Twig\Extension\FlashMessageRuntime::class,
+    __NAMESPACE__.'\FlashMessageRuntime'
+);

--- a/src/CoreBundle/Twig/Extension/FormTypeExtension.php
+++ b/src/CoreBundle/Twig/Extension/FormTypeExtension.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Twig\Extension;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class FormTypeExtension extends \Sonata\Twig\Extension\FormTypeExtension
-{
-}
+class_alias(
+    \Sonata\Twig\Extension\FormTypeExtension::class,
+    __NAMESPACE__.'\FormTypeExtension'
+);

--- a/src/CoreBundle/Twig/Extension/StatusRuntime.php
+++ b/src/CoreBundle/Twig/Extension/StatusRuntime.php
@@ -17,12 +17,7 @@ namespace Sonata\CoreBundle\Twig\Extension;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Hugo Briand <briand@ekino.com>
- * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-final class StatusRuntime extends \Sonata\Twig\Extension\StatusRuntime
-{
-}
+class_alias(
+    \Sonata\Twig\Extension\StatusRuntime::class,
+    __NAMESPACE__.'\StatusRuntime'
+);

--- a/src/CoreBundle/Twig/Extension/TemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/TemplateExtension.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Twig\Extension;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class TemplateExtension extends \Sonata\Twig\Extension\TemplateExtension
-{
-}
+class_alias(
+    \Sonata\Twig\Extension\TemplateExtension::class,
+    __NAMESPACE__.'\TemplateExtension'
+);

--- a/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
+++ b/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Twig\Node;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Marko Kunic <kunicmarko20@gmail.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-final class DeprecatedTemplateNode extends \Sonata\Twig\Node\DeprecatedTemplateNode
-{
-}
+class_alias(
+    \Sonata\Twig\Node\DeprecatedTemplateNode::class,
+    __NAMESPACE__.'\DeprecatedTemplateNode'
+);

--- a/src/CoreBundle/Twig/Node/TemplateBoxNode.php
+++ b/src/CoreBundle/Twig/Node/TemplateBoxNode.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Twig\Node;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class TemplateBoxNode extends \Sonata\Twig\Node\TemplateBoxNode
-{
-}
+class_alias(
+    \Sonata\Twig\Node\TemplateBoxNode::class,
+    __NAMESPACE__.'\TemplateBoxNode'
+);

--- a/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
@@ -17,11 +17,7 @@ namespace Sonata\CoreBundle\Twig\TokenParser;
     E_USER_DEPRECATED
 );
 
-/**
- * @author Marko Kunic <kunicmarko20@gmail.com>
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-final class DeprecatedTemplateTokenParser extends \Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser
-{
-}
+class_alias(
+    \Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser::class,
+    __NAMESPACE__.'\DeprecatedTemplateTokenParser'
+);

--- a/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Twig\TokenParser;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class TemplateBoxTokenParser extends \Sonata\Twig\TokenParser\TemplateBoxTokenParser
-{
-}
+class_alias(
+    \Sonata\Twig\TokenParser\TemplateBoxTokenParser::class,
+    __NAMESPACE__.'\TemplateBoxTokenParser'
+);

--- a/src/CoreBundle/Validator/Constraints/InlineConstraint.php
+++ b/src/CoreBundle/Validator/Constraints/InlineConstraint.php
@@ -17,14 +17,7 @@ namespace Sonata\CoreBundle\Validator\Constraints;
     E_USER_DEPRECATED
 );
 
-/**
- * Constraint which allows inline-validation inside services.
- *
- * @Annotation
- * @Target({"CLASS"})
- *
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class InlineConstraint extends \Sonata\Form\Validator\Constraints\InlineConstraint
-{
-}
+class_alias(
+    \Sonata\Form\Validator\Constraints\InlineConstraint::class,
+    __NAMESPACE__.'\InlineConstraint'
+);

--- a/src/CoreBundle/Validator/ErrorElement.php
+++ b/src/CoreBundle/Validator/ErrorElement.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Validator;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class ErrorElement extends \Sonata\Form\Validator\ErrorElement
-{
-}
+class_alias(
+    \Sonata\Form\Validator\ErrorElement::class,
+    __NAMESPACE__.'\ErrorElement'
+);

--- a/src/CoreBundle/Validator/InlineValidator.php
+++ b/src/CoreBundle/Validator/InlineValidator.php
@@ -17,9 +17,7 @@ namespace Sonata\CoreBundle\Validator;
     E_USER_DEPRECATED
 );
 
-/**
- * @deprecated Since version 3.x, to be removed in 4.0.
- */
-class InlineValidator extends \Sonata\Form\Validator\InlineValidator
-{
-}
+class_alias(
+    \Sonata\Form\Validator\InlineValidator::class,
+    __NAMESPACE__.'\InlineValidator'
+);

--- a/tests/CoreBundle/Validator/Constraints/InlineConstraintTest.php
+++ b/tests/CoreBundle/Validator/Constraints/InlineConstraintTest.php
@@ -76,7 +76,7 @@ class InlineConstraintTest extends TestCase
         $constraint = new InlineConstraint(['service' => 'foo', 'method' => function () {
         }, 'serializingWarning' => true]);
 
-        $expected = 'O:56:"Sonata\CoreBundle\Validator\Constraints\InlineConstraint":0:{}';
+        $expected = 'O:50:"Sonata\Form\Validator\Constraints\InlineConstraint":0:{}';
 
         $this->assertSame($expected, serialize($constraint));
 

--- a/tests/CoreBundle/Validator/ErrorElementTest.php
+++ b/tests/CoreBundle/Validator/ErrorElementTest.php
@@ -230,7 +230,7 @@ class ErrorElementTest extends TestCase
             'InvalidArgumentException'
         );
         $this->expectExceptionMessage(
-            'Argument 3 passed to Sonata\CoreBundle\Validator\ErrorElement::__construct() must be an instance of '.
+            'Argument 3 passed to Sonata\Form\Validator\ErrorElement::__construct() must be an instance of '.
             'Symfony\Component\Validator\ExecutionContextInterface or '.
             'Symfony\Component\Validator\Context\ExecutionContextInterface.'
         );


### PR DESCRIPTION
Refs #609
## Subject

Several issues have been reported because of type hinting issues: code
would type hint against the extending class, and receive a class of the
extended type, for instance. Aliasing solves that kind of issue by
making both types equivalent.

I am targeting this branch, because this is BC.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- several crashes about type hint issues
```

Note that I couldn't do it for some classes extending `BasePickerType`, not sure why but there was an error about too few arguments…