### PR TITLE
Trick Composer into generating class maps

### DIFF
--- a/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
+++ b/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
@@ -21,3 +21,14 @@ class_alias(
     '\Sonata\Twig\Status\StatusClassRendererInterface',
     '\Sonata\CoreBundle\Component\Status\StatusClassRendererInterface'
 );
+
+if (false) {
+    /**
+     * @author Hugo Briand <briand@ekino.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    interface StatusClassRendererInterface extends \Sonata\Twig\Status\StatusClassRendererInterface
+    {
+    }
+}

--- a/src/CoreBundle/Date/MomentFormatConverter.php
+++ b/src/CoreBundle/Date/MomentFormatConverter.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Date\MomentFormatConverter::class,
     __NAMESPACE__.'\MomentFormatConverter'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class MomentFormatConverter extends \Sonata\Form\Date\MomentFormatConverter
+    {
+    }
+}

--- a/src/CoreBundle/FlashMessage/FlashManager.php
+++ b/src/CoreBundle/FlashMessage/FlashManager.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Twig\FlashMessage\FlashManager::class,
     __NAMESPACE__.'\FlashManager'
 );
+
+if (false) {
+    /**
+     * @author Vincent Composieux <composieux@ekino.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class FlashManager extends \Sonata\Twig\FlashMessage\FlashManager
+    {
+    }
+}

--- a/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
+++ b/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer::class,
     __NAMESPACE__.'\BooleanTypeToBooleanTransformer'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class BooleanTypeToBooleanTransformer extends \Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\BaseDoctrineORMSerializationType::class,
     __NAMESPACE__.'\BaseDoctrineORMSerializationType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class BaseDoctrineORMSerializationType extends \Sonata\Form\Type\BaseDoctrineORMSerializationType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/BasePickerType.php
+++ b/src/CoreBundle/Form/Type/BasePickerType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\BasePickerType::class,
     __NAMESPACE__.'\BasePickerType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    abstract class BasePickerType extends \Sonata\Form\Type\BasePickerType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/BaseStatusType.php
+++ b/src/CoreBundle/Form/Type/BaseStatusType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\BaseStatusType::class,
     __NAMESPACE__.'\BaseStatusType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    abstract class BaseStatusType extends \Sonata\Form\Type\BaseStatusType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\BooleanType::class,
     __NAMESPACE__.'\BooleanType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class BooleanType extends \Sonata\Form\Type\BooleanType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\CollectionType::class,
     __NAMESPACE__.'\CollectionType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class CollectionType extends \Sonata\Form\Type\CollectionType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\DateRangePickerType::class,
     __NAMESPACE__.'\DateRangePickerType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\DateRangeType::class,
     __NAMESPACE__.'\DateRangeType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class DateRangeType extends \Sonata\Form\Type\DateRangeType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\DateTimeRangePickerType::class,
     __NAMESPACE__.'\DateTimeRangePickerType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\DateTimeRangeType::class,
     __NAMESPACE__.'\DateTimeRangeType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\EqualType::class,
     __NAMESPACE__.'\EqualType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class EqualType extends \Sonata\Form\Type\EqualType
+    {
+    }
+}

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Type\ImmutableArrayType::class,
     __NAMESPACE__.'\ImmutableArrayType'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
+    {
+    }
+}

--- a/src/CoreBundle/Model/Adapter/AdapterChain.php
+++ b/src/CoreBundle/Model/Adapter/AdapterChain.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Doctrine\Adapter\AdapterChain::class,
     __NAMESPACE__.'\AdapterChain'
 );
+
+if (false) {
+    /**
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    class AdapterChain extends \Sonata\Doctrine\Adapter\AdapterChain implements AdapterInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/Adapter/AdapterInterface.php
+++ b/src/CoreBundle/Model/Adapter/AdapterInterface.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Doctrine\Adapter\AdapterInterface::class,
     __NAMESPACE__.'\AdapterInterface'
 );
+
+if (false) {
+    /**
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    interface AdapterInterface extends \Sonata\Doctrine\Adapter\AdapterInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter::class,
     __NAMESPACE__.'\DoctrineORMAdapter'
 );
+
+if (false) {
+    /**
+     * This is a port of the DoctrineORMAdminBundle / ModelManager class.
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    class DoctrineORMAdapter extends \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter implements AdapterInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter::class,
     __NAMESPACE__.'\DoctrinePHPCRAdapter'
 );
+
+if (false) {
+    /**
+     * This is a port of the DoctrineORMAdminBundle / ModelManager class.
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    class DoctrinePHPCRAdapter extends \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter implements AdapterInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/BaseDocumentManager.php
+++ b/src/CoreBundle/Model/BaseDocumentManager.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Document\BaseDocumentManager::class,
     __NAMESPACE__.'\BaseDocumentManager'
 );
+
+if (false) {
+    /**
+     * @author Hugo Briand <briand@ekino.com>
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    abstract class BaseDocumentManager extends \Sonata\Doctrine\Document\BaseDocumentManager implements ManagerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/BaseEntityManager.php
+++ b/src/CoreBundle/Model/BaseEntityManager.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Entity\BaseEntityManager::class,
     __NAMESPACE__.'\BaseEntityManager'
 );
+
+if (false) {
+    /**
+     * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    abstract class BaseEntityManager extends \Sonata\Doctrine\Entity\BaseEntityManager implements ManagerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/BaseManager.php
+++ b/src/CoreBundle/Model/BaseManager.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Model\BaseManager::class,
     __NAMESPACE__.'\BaseManager'
 );
+
+if (false) {
+    /**
+     * @author Hugo Briand <briand@ekino.com>
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    abstract class BaseManager extends \Sonata\Doctrine\Model\BaseManager implements ManagerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/BasePHPCRManager.php
+++ b/src/CoreBundle/Model/BasePHPCRManager.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Doctrine\Document\BasePHPCRManager::class,
     __NAMESPACE__.'\BasePHPCRManager'
 );
+
+if (false) {
+    /**
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    abstract class BasePHPCRManager extends \Sonata\Doctrine\Document\BasePHPCRManager implements ManagerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Model/ManagerInterface.php
+++ b/src/CoreBundle/Model/ManagerInterface.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Doctrine\Model\ManagerInterface::class,
     __NAMESPACE__.'\ManagerInterface'
 );
+
+if (false) {
+    /**
+     * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    interface ManagerInterface extends \Sonata\Doctrine\Model\ManagerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Serializer/BaseSerializerHandler.php
+++ b/src/CoreBundle/Serializer/BaseSerializerHandler.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Serializer\BaseSerializerHandler::class,
     __NAMESPACE__.'\BaseSerializerHandler'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    abstract class BaseSerializerHandler extends \Sonata\Serializer\BaseSerializerHandler implements SerializerHandlerInterface
+    {
+    }
+}

--- a/src/CoreBundle/Serializer/SerializerHandlerInterface.php
+++ b/src/CoreBundle/Serializer/SerializerHandlerInterface.php
@@ -21,3 +21,16 @@ class_alias(
     \Sonata\Serializer\SerializerHandlerInterface::class,
     __NAMESPACE__.'\SerializerHandlerInterface'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    interface SerializerHandlerInterface extends \Sonata\Serializer\SerializerHandlerInterface
+    {
+        /**
+         * @return string
+         */
+        public static function getType();
+    }
+}

--- a/src/CoreBundle/Test/AbstractWidgetTestCase.php
+++ b/src/CoreBundle/Test/AbstractWidgetTestCase.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Test\AbstractWidgetTestCase::class,
     __NAMESPACE__.'\AbstractWidgetTestCase'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    abstract class AbstractWidgetTestCase extends \Sonata\Form\Test\AbstractWidgetTestCase
+    {
+    }
+}

--- a/src/CoreBundle/Test/EntityManagerMockFactory.php
+++ b/src/CoreBundle/Test/EntityManagerMockFactory.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Doctrine\Test\EntityManagerMockFactory::class,
     __NAMESPACE__.'\EntityManagerMockFactory'
 );
+
+if (false) {
+    /**
+     * @deprecated since 3.x, to be removed in 4.0.
+     */
+    class EntityManagerMockFactory extends \Sonata\Doctrine\Test\EntityManagerMockFactory
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Twig\Extension\DeprecatedTemplateExtension::class,
     __NAMESPACE__.'\DeprecatedTemplateExtension'
 );
+
+if (false) {
+    /**
+     * @author Marko Kunic <kunicmarko20@gmail.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    final class DeprecatedTemplateExtension extends \Sonata\Twig\Extension\DeprecatedTemplateExtension
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
+++ b/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
@@ -21,3 +21,17 @@ class_alias(
     \Sonata\Twig\Extension\FlashMessageRuntime::class,
     __NAMESPACE__.'\FlashMessageRuntime'
 );
+
+if (false) {
+    /**
+     * This is the Sonata core flash message Twig runtime.
+     *
+     * @author Vincent Composieux <composieux@ekino.com>
+     * @author Titouan Galopin <galopintitouan@gmail.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    final class FlashMessageRuntime extends \Sonata\Twig\Extension\FlashMessageRuntime
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Extension/FormTypeExtension.php
+++ b/src/CoreBundle/Twig/Extension/FormTypeExtension.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Twig\Extension\FormTypeExtension::class,
     __NAMESPACE__.'\FormTypeExtension'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class FormTypeExtension extends \Sonata\Twig\Extension\FormTypeExtension
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Extension/StatusRuntime.php
+++ b/src/CoreBundle/Twig/Extension/StatusRuntime.php
@@ -21,3 +21,15 @@ class_alias(
     \Sonata\Twig\Extension\StatusRuntime::class,
     __NAMESPACE__.'\StatusRuntime'
 );
+
+if (false) {
+    /**
+     * @author Hugo Briand <briand@ekino.com>
+     * @author Titouan Galopin <galopintitouan@gmail.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    final class StatusRuntime extends \Sonata\Twig\Extension\StatusRuntime
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Extension/TemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/TemplateExtension.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Twig\Extension\TemplateExtension::class,
     __NAMESPACE__.'\TemplateExtension'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class TemplateExtension extends \Sonata\Twig\Extension\TemplateExtension
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
+++ b/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Twig\Node\DeprecatedTemplateNode::class,
     __NAMESPACE__.'\DeprecatedTemplateNode'
 );
+
+if (false) {
+    /**
+     * @author Marko Kunic <kunicmarko20@gmail.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    final class DeprecatedTemplateNode extends \Sonata\Twig\Node\DeprecatedTemplateNode
+    {
+    }
+}

--- a/src/CoreBundle/Twig/Node/TemplateBoxNode.php
+++ b/src/CoreBundle/Twig/Node/TemplateBoxNode.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Twig\Node\TemplateBoxNode::class,
     __NAMESPACE__.'\TemplateBoxNode'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class TemplateBoxNode extends \Sonata\Twig\Node\TemplateBoxNode
+    {
+    }
+}

--- a/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
@@ -21,3 +21,14 @@ class_alias(
     \Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser::class,
     __NAMESPACE__.'\DeprecatedTemplateTokenParser'
 );
+
+if (false) {
+    /**
+     * @author Marko Kunic <kunicmarko20@gmail.com>
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    final class DeprecatedTemplateTokenParser extends \Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser
+    {
+    }
+}

--- a/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Twig\TokenParser\TemplateBoxTokenParser::class,
     __NAMESPACE__.'\TemplateBoxTokenParser'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class TemplateBoxTokenParser extends \Sonata\Twig\TokenParser\TemplateBoxTokenParser
+    {
+    }
+}

--- a/src/CoreBundle/Validator/Constraints/InlineConstraint.php
+++ b/src/CoreBundle/Validator/Constraints/InlineConstraint.php
@@ -21,3 +21,17 @@ class_alias(
     \Sonata\Form\Validator\Constraints\InlineConstraint::class,
     __NAMESPACE__.'\InlineConstraint'
 );
+
+if (false) {
+    /**
+     * Constraint which allows inline-validation inside services.
+     *
+     * @Annotation
+     * @Target({"CLASS"})
+     *
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class InlineConstraint extends \Sonata\Form\Validator\Constraints\InlineConstraint
+    {
+    }
+}

--- a/src/CoreBundle/Validator/ErrorElement.php
+++ b/src/CoreBundle/Validator/ErrorElement.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Validator\ErrorElement::class,
     __NAMESPACE__.'\ErrorElement'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class ErrorElement extends \Sonata\Form\Validator\ErrorElement
+    {
+    }
+}

--- a/src/CoreBundle/Validator/InlineValidator.php
+++ b/src/CoreBundle/Validator/InlineValidator.php
@@ -21,3 +21,12 @@ class_alias(
     \Sonata\Form\Validator\InlineValidator::class,
     __NAMESPACE__.'\InlineValidator'
 );
+
+if (false) {
+    /**
+     * @deprecated Since version 3.x, to be removed in 4.0.
+     */
+    class InlineValidator extends \Sonata\Form\Validator\InlineValidator
+    {
+    }
+}


### PR DESCRIPTION
## Subject

Currently, Composer uses a simple grep-like mechanism to detect whether
he should add a file to the class map. Putting a fake declaration inside
an if false statement can trick it into doing its job.

I am targeting this branch, because this is BC.

Fixes #618

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crashes when using `composer install --classmap-authoritative`
```