### PR TITLE
Trigger autoload for legacy types

### DIFF
--- a/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
+++ b/src/CoreBundle/Component/Status/StatusClassRendererInterface.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Component\Status;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\StatusClassRendererInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Status\StatusClassRendererInterface instead.',
-    E_USER_DEPRECATED
-);
+if (!interface_exists('\Sonata\Twig\Status\StatusClassRendererInterface', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\StatusClassRendererInterface class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Status\StatusClassRendererInterface instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     '\Sonata\Twig\Status\StatusClassRendererInterface',

--- a/src/CoreBundle/Date/MomentFormatConverter.php
+++ b/src/CoreBundle/Date/MomentFormatConverter.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Date;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\MomentFormatConverter class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Date\MomentFormatConverter instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Date\MomentFormatConverter::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\MomentFormatConverter class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Date\MomentFormatConverter instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Date\MomentFormatConverter::class,

--- a/src/CoreBundle/FlashMessage/FlashManager.php
+++ b/src/CoreBundle/FlashMessage/FlashManager.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\FlashMessage;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\FlashManager class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\FlashMessage\FlashManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\FlashMessage\FlashManager::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\FlashManager class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\FlashMessage\FlashManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\FlashMessage\FlashManager::class,

--- a/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
+++ b/src/CoreBundle/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\DataTransformer;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BooleanTypeToBooleanTransformer class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BooleanTypeToBooleanTransformer class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\DataTransformer\BooleanTypeToBooleanTransformer::class,

--- a/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/src/CoreBundle/Form/Type/BaseDoctrineORMSerializationType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseDoctrineORMSerializationType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\BaseDoctrineORMSerializationType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\BaseDoctrineORMSerializationType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseDoctrineORMSerializationType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\BaseDoctrineORMSerializationType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\BaseDoctrineORMSerializationType::class,

--- a/src/CoreBundle/Form/Type/BasePickerType.php
+++ b/src/CoreBundle/Form/Type/BasePickerType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BasePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\BasePickerType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\BasePickerType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BasePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\BasePickerType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\BasePickerType::class,

--- a/src/CoreBundle/Form/Type/BaseStatusType.php
+++ b/src/CoreBundle/Form/Type/BaseStatusType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseStatusType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\BaseStatusType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\BaseStatusType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseStatusType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\BaseStatusType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\BaseStatusType::class,

--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BooleanType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\BooleanType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\BooleanType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BooleanType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\BooleanType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\BooleanType::class,

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\CollectionType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\CollectionType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\CollectionType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\CollectionType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\CollectionType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\CollectionType::class,

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DateRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DateRangePickerType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\DateRangePickerType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DateRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\DateRangePickerType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\DateRangePickerType::class,

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DateRangeType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DateRangeType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\DateRangeType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DateRangeType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\DateRangeType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\DateRangeType::class,

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DateTimeRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DateTimeRangePickerType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\DateTimeRangePickerType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DateTimeRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\DateTimeRangePickerType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\DateTimeRangePickerType::class,

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DateTimeRangeType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DateTimeRangeType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\DateTimeRangeType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DateTimeRangeType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\DateTimeRangeType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\DateTimeRangeType::class,

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\EqualType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\EqualType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\EqualType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\EqualType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\EqualType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\EqualType::class,

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\ImmutableArrayType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\ImmutableArrayType instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Type\ImmutableArrayType::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ImmutableArrayType class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Type\ImmutableArrayType instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Type\ImmutableArrayType::class,

--- a/src/CoreBundle/Model/Adapter/AdapterChain.php
+++ b/src/CoreBundle/Model/Adapter/AdapterChain.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Adapter\AdapterChain instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Adapter\AdapterChain::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\AdapterChain class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Adapter\AdapterChain instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Adapter\AdapterChain::class,

--- a/src/CoreBundle/Model/Adapter/AdapterInterface.php
+++ b/src/CoreBundle/Model/Adapter/AdapterInterface.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Adapter\AdapterInterface instead.',
-    E_USER_DEPRECATED
-);
+if (!interface_exists(\Sonata\Doctrine\Adapter\AdapterInterface::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Adapter\AdapterInterface instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Adapter\AdapterInterface::class,

--- a/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrineORMAdapter.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DoctrineORMAdapter class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Adapter\ORM\DoctrineORMAdapter::class,

--- a/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
+++ b/src/CoreBundle/Model/Adapter/DoctrinePHPCRAdapter.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model\Adapter;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdapterInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DoctrinePHPCRAdapter class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Adapter\PHPCR\DoctrinePHPCRAdapter::class,

--- a/src/CoreBundle/Model/BaseDocumentManager.php
+++ b/src/CoreBundle/Model/BaseDocumentManager.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseDocumentManager class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Document\BaseDocumentManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Document\BaseDocumentManager::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseDocumentManager class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Document\BaseDocumentManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Document\BaseDocumentManager::class,

--- a/src/CoreBundle/Model/BaseEntityManager.php
+++ b/src/CoreBundle/Model/BaseEntityManager.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseEntityManager class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Entity\BaseEntityManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Entity\BaseEntityManager::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseEntityManager class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Entity\BaseEntityManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Entity\BaseEntityManager::class,

--- a/src/CoreBundle/Model/BaseManager.php
+++ b/src/CoreBundle/Model/BaseManager.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseManager class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Model\BaseManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Model\BaseManager::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseManager class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Model\BaseManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Model\BaseManager::class,

--- a/src/CoreBundle/Model/BasePHPCRManager.php
+++ b/src/CoreBundle/Model/BasePHPCRManager.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BasePHPCRManager class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Document\BasePHPCRManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Document\BasePHPCRManager::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BasePHPCRManager class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Document\BasePHPCRManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Document\BasePHPCRManager::class,

--- a/src/CoreBundle/Model/ManagerInterface.php
+++ b/src/CoreBundle/Model/ManagerInterface.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Model\ManagerInterface instead.',
-    E_USER_DEPRECATED
-);
+if (interface_exists(\Sonata\Doctrine\Model\ManagerInterface::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Model\ManagerInterface instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Model\ManagerInterface::class,

--- a/src/CoreBundle/Model/PageableManagerInterface.php
+++ b/src/CoreBundle/Model/PageableManagerInterface.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Model;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\DatagridBundle\Pager\PageableInterface instead.',
-    E_USER_DEPRECATED
-);
+if (interface_exists(\Sonata\Doctrine\Model\PageableManagerInterface::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\DatagridBundle\Pager\PageableInterface instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Model\PageableManagerInterface::class,

--- a/src/CoreBundle/Serializer/BaseSerializerHandler.php
+++ b/src/CoreBundle/Serializer/BaseSerializerHandler.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Serializer;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\BaseSerializerHandler class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Serializer\BaseSerializerHandler instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Serializer\BaseSerializerHandler::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\BaseSerializerHandler class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Serializer\BaseSerializerHandler instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Serializer\BaseSerializerHandler::class,

--- a/src/CoreBundle/Serializer/SerializerHandlerInterface.php
+++ b/src/CoreBundle/Serializer/SerializerHandlerInterface.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Serializer;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\SerializerHandlerInterface class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Serializer\SerializerHandlerInterface instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Serializer\SerializerHandlerInterface::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SerializerHandlerInterface class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Serializer\SerializerHandlerInterface instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Serializer\SerializerHandlerInterface::class,

--- a/src/CoreBundle/Test/AbstractWidgetTestCase.php
+++ b/src/CoreBundle/Test/AbstractWidgetTestCase.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Test;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AbstractWidgetTestCase class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Test\AbstractWidgetTestCase instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Test\AbstractWidgetTestCase::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\AbstractWidgetTestCase class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Test\AbstractWidgetTestCase instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Test\AbstractWidgetTestCase::class,

--- a/src/CoreBundle/Test/EntityManagerMockFactory.php
+++ b/src/CoreBundle/Test/EntityManagerMockFactory.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Test;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\EntityManagerMockFactory class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Doctrine\Test\EntityManagerMockFactory instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Doctrine\Test\EntityManagerMockFactory::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\EntityManagerMockFactory class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Doctrine\Test\EntityManagerMockFactory instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Doctrine\Test\EntityManagerMockFactory::class,

--- a/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/DeprecatedTemplateExtension.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DeprecatedTemplateExtension class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Extension\DeprecatedTemplateExtension instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Extension\DeprecatedTemplateExtension::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DeprecatedTemplateExtension class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Extension\DeprecatedTemplateExtension instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Extension\DeprecatedTemplateExtension::class,

--- a/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
+++ b/src/CoreBundle/Twig/Extension/FlashMessageRuntime.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\FlashMessageRuntime class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Extension\FlashMessageRuntime instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Extension\FlashMessageRuntime::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\FlashMessageRuntime class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Extension\FlashMessageRuntime instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Extension\FlashMessageRuntime::class,

--- a/src/CoreBundle/Twig/Extension/FormTypeExtension.php
+++ b/src/CoreBundle/Twig/Extension/FormTypeExtension.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\FormTypeExtension class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Extension\FormTypeExtension instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Extension\FormTypeExtension::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\FormTypeExtension class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Extension\FormTypeExtension instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Extension\FormTypeExtension::class,

--- a/src/CoreBundle/Twig/Extension/StatusRuntime.php
+++ b/src/CoreBundle/Twig/Extension/StatusRuntime.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\StatusRuntime class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Extension\StatusRuntime instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Extension\StatusRuntime::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\StatusRuntime class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Extension\StatusRuntime instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Extension\StatusRuntime::class,

--- a/src/CoreBundle/Twig/Extension/TemplateExtension.php
+++ b/src/CoreBundle/Twig/Extension/TemplateExtension.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Extension;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\TemplateExtension class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Extension\TemplateExtension instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Extension\TemplateExtension::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\TemplateExtension class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Extension\TemplateExtension instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Extension\TemplateExtension::class,

--- a/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
+++ b/src/CoreBundle/Twig/Node/DeprecatedTemplateNode.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DeprecatedTemplateNode class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Node\DeprecatedTemplateNode\FlashManager instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Node\DeprecatedTemplateNode::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DeprecatedTemplateNode class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Node\DeprecatedTemplateNode\FlashManager instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Node\DeprecatedTemplateNode::class,

--- a/src/CoreBundle/Twig/Node/TemplateBoxNode.php
+++ b/src/CoreBundle/Twig/Node/TemplateBoxNode.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\Node;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\TemplateBoxNode class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\Node\TemplateBoxNode instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\Node\TemplateBoxNode::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\TemplateBoxNode class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\Node\TemplateBoxNode instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\Node\TemplateBoxNode::class,

--- a/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/DeprecatedTemplateTokenParser.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DeprecatedTemplateTokenParser class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DeprecatedTemplateTokenParser class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\TokenParser\DeprecatedTemplateTokenParser::class,

--- a/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/CoreBundle/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Twig\TokenParser;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\TemplateBoxTokenParser class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Twig\TokenParser\TemplateBoxTokenParser instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Twig\TokenParser\TemplateBoxTokenParser::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\TemplateBoxTokenParser class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Twig\TokenParser\TemplateBoxTokenParser instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Twig\TokenParser\TemplateBoxTokenParser::class,

--- a/src/CoreBundle/Validator/ErrorElement.php
+++ b/src/CoreBundle/Validator/ErrorElement.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Validator;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\ErrorElement class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Validator\ErrorElement instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Validator\ErrorElement::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ErrorElement class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Validator\ErrorElement instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Validator\ErrorElement::class,

--- a/src/CoreBundle/Validator/InlineValidator.php
+++ b/src/CoreBundle/Validator/InlineValidator.php
@@ -11,11 +11,13 @@
 
 namespace Sonata\CoreBundle\Validator;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\InlineValidator class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Validator\InlineValidator instead.',
-    E_USER_DEPRECATED
-);
+if (!class_exists(\Sonata\Form\Validator\InlineValidator::class, false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\InlineValidator class is deprecated since version 3.x and will be removed in 4.0.'
+        .' Use Sonata\Form\Validator\InlineValidator instead.',
+        E_USER_DEPRECATED
+    );
+}
 
 class_alias(
     \Sonata\Form\Validator\InlineValidator::class,

--- a/src/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
+++ b/src/Form/DataTransformer/BooleanTypeToBooleanTransformer.php
@@ -38,3 +38,5 @@ class BooleanTypeToBooleanTransformer implements DataTransformerInterface
         return null;
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\DataTransformer\BooleanTypeToBooleanTransformer::class);

--- a/src/Form/Date/MomentFormatConverter.php
+++ b/src/Form/Date/MomentFormatConverter.php
@@ -103,3 +103,5 @@ class MomentFormatConverter
         return $output;
     }
 }
+
+class_exists(\Sonata\CoreBundle\Date\MomentFormatConverter::class);

--- a/src/Form/Test/AbstractWidgetTestCase.php
+++ b/src/Form/Test/AbstractWidgetTestCase.php
@@ -181,3 +181,5 @@ abstract class AbstractWidgetTestCase extends TypeTestCase
         }, $html);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Test\AbstractWidgetTestCase::class);

--- a/src/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Form/Type/BaseDoctrineORMSerializationType.php
@@ -163,3 +163,5 @@ class BaseDoctrineORMSerializationType extends AbstractType
         ]);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\BaseDoctrineORMSerializationType::class);

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -170,3 +170,5 @@ abstract class BasePickerType extends AbstractType
         ];
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\BasePickerType::class);

--- a/src/Form/Type/BaseStatusType.php
+++ b/src/Form/Type/BaseStatusType.php
@@ -111,3 +111,5 @@ abstract class BaseStatusType extends AbstractType
         ]);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\BaseStatusType::class);

--- a/src/Form/Type/BooleanType.php
+++ b/src/Form/Type/BooleanType.php
@@ -98,3 +98,5 @@ class BooleanType extends AbstractType
         return 'sonata_type_boolean';
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\BooleanType::class);

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -72,3 +72,5 @@ class CollectionType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\CollectionType::class);

--- a/src/Form/Type/DateRangePickerType.php
+++ b/src/Form/Type/DateRangePickerType.php
@@ -42,3 +42,5 @@ class DateRangePickerType extends DateRangeType
         return $this->getBlockPrefix();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\DateRangePickerType::class);

--- a/src/Form/Type/DateRangeType.php
+++ b/src/Form/Type/DateRangeType.php
@@ -100,3 +100,5 @@ class DateRangeType extends AbstractType
         ]);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\DateRangeType::class);

--- a/src/Form/Type/DateTimeRangePickerType.php
+++ b/src/Form/Type/DateTimeRangePickerType.php
@@ -42,3 +42,5 @@ class DateTimeRangePickerType extends DateTimeRangeType
         return $this->getBlockPrefix();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\DateTimeRangePickerType::class);

--- a/src/Form/Type/DateTimeRangeType.php
+++ b/src/Form/Type/DateTimeRangeType.php
@@ -100,3 +100,5 @@ class DateTimeRangeType extends AbstractType
         ]);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\DateTimeRangeType::class);

--- a/src/Form/Type/EqualType.php
+++ b/src/Form/Type/EqualType.php
@@ -95,3 +95,5 @@ class EqualType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\EqualType::class);

--- a/src/Form/Type/ImmutableArrayType.php
+++ b/src/Form/Type/ImmutableArrayType.php
@@ -80,3 +80,5 @@ class ImmutableArrayType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Form\Type\ImmutableArrayType::class);

--- a/src/Form/Validator/Constraints/InlineConstraint.php
+++ b/src/Form/Validator/Constraints/InlineConstraint.php
@@ -129,3 +129,5 @@ class InlineConstraint extends Constraint
         return $this->serializingWarning;
     }
 }
+
+class_exists(\Sonata\CoreBundle\Validator\Constraints\InlineConstraint::class);

--- a/src/Form/Validator/ErrorElement.php
+++ b/src/Form/Validator/ErrorElement.php
@@ -265,3 +265,5 @@ class ErrorElement
         return $this->propertyPaths[$this->current];
     }
 }
+
+class_exists(\Sonata\CoreBundle\Validator\ErrorElement::class);

--- a/src/Form/Validator/InlineValidator.php
+++ b/src/Form/Validator/InlineValidator.php
@@ -68,3 +68,5 @@ class InlineValidator extends ConstraintValidator
         );
     }
 }
+
+class_exists(\Sonata\CoreBundle\Validator\InlineValidator::class);

--- a/src/Serializer/BaseSerializerHandler.php
+++ b/src/Serializer/BaseSerializerHandler.php
@@ -118,3 +118,5 @@ abstract class BaseSerializerHandler implements SerializerHandlerInterface
         return $this->manager->findOneBy(['id' => $data]);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Serializer\BaseSerializerHandler::class);

--- a/src/Serializer/SerializerHandlerInterface.php
+++ b/src/Serializer/SerializerHandlerInterface.php
@@ -23,3 +23,5 @@ interface SerializerHandlerInterface extends SubscribingHandlerInterface
      */
     public static function getType();
 }
+
+interface_exists(\Sonata\CoreBundle\Serializer\SerializerHandlerInterface::class);

--- a/src/Twig/Extension/DeprecatedTemplateExtension.php
+++ b/src/Twig/Extension/DeprecatedTemplateExtension.php
@@ -26,3 +26,5 @@ class DeprecatedTemplateExtension extends AbstractExtension
         ];
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Extension\DeprecatedTemplateExtension::class);

--- a/src/Twig/Extension/FlashMessageRuntime.php
+++ b/src/Twig/Extension/FlashMessageRuntime.php
@@ -51,3 +51,5 @@ class FlashMessageRuntime
         return $this->flashManager->getHandledTypes();
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Extension\FlashMessageRuntime::class);

--- a/src/Twig/Extension/FormTypeExtension.php
+++ b/src/Twig/Extension/FormTypeExtension.php
@@ -38,3 +38,5 @@ class FormTypeExtension extends AbstractExtension implements GlobalsInterface
         return 'sonata_core_wrapping';
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Extension\FormTypeExtension::class);

--- a/src/Twig/Extension/StatusRuntime.php
+++ b/src/Twig/Extension/StatusRuntime.php
@@ -52,3 +52,5 @@ class StatusRuntime
         return $default;
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Extension\StatusRuntime::class);

--- a/src/Twig/Extension/TemplateExtension.php
+++ b/src/Twig/Extension/TemplateExtension.php
@@ -99,3 +99,5 @@ class TemplateExtension extends AbstractExtension
         return 'sonata_core_template';
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Extension\TemplateExtension::class);

--- a/src/Twig/FlashMessage/FlashManager.php
+++ b/src/Twig/FlashMessage/FlashManager.php
@@ -155,3 +155,5 @@ class FlashManager implements StatusClassRendererInterface
         }
     }
 }
+
+class_exists(\Sonata\CoreBundle\FlashMessage\FlashManager::class);

--- a/src/Twig/Node/DeprecatedTemplateNode.php
+++ b/src/Twig/Node/DeprecatedTemplateNode.php
@@ -34,3 +34,5 @@ class DeprecatedTemplateNode extends Node
         ), E_USER_DEPRECATED);
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Node\DeprecatedTemplateNode::class);

--- a/src/Twig/Node/TemplateBoxNode.php
+++ b/src/Twig/Node/TemplateBoxNode.php
@@ -89,3 +89,5 @@ CODE;
             ->write("echo $message;");
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\Node\TemplateBoxNode::class);

--- a/src/Twig/TokenParser/DeprecatedTemplateTokenParser.php
+++ b/src/Twig/TokenParser/DeprecatedTemplateTokenParser.php
@@ -38,3 +38,5 @@ class DeprecatedTemplateTokenParser extends AbstractTokenParser
         return 'sonata_template_deprecate';
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\TokenParser\DeprecatedTemplateTokenParser::class);

--- a/src/Twig/TokenParser/TemplateBoxTokenParser.php
+++ b/src/Twig/TokenParser/TemplateBoxTokenParser.php
@@ -62,3 +62,5 @@ class TemplateBoxTokenParser extends AbstractTokenParser
         return 'sonata_template_box';
     }
 }
+
+class_exists(\Sonata\CoreBundle\Twig\TokenParser\TemplateBoxTokenParser::class);


### PR DESCRIPTION
## Subject

By loading the deprecated types, we make sure the class alias they
contain exist, so that code type hinting against the old type accepts
the new. This is necessary because type hinting does not trigger
autoload, since it usually does not need to.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crashes when a class type hints against an old type, but receives a new one
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

Resolves:

```
Argument 1 passed to Sonata\AdminBundle\Admin\AbstractAdmin::Sonata\AdminBundle\Admin\{closure}() must be an instance of Sonata\CoreBundle\Validator\ErrorElement, instance of Sonata\Form\Validator\ErrorElement given, called in /Storage/www/sonata/sonata-test/lib/vendor/sonata-project/core-bundle/src/Form/Validator/InlineValidator.php on line 53
```