### PR TITLE
Add missing service definition

### DIFF
--- a/src/CoreBundle/Resources/config/form_types.xml
+++ b/src/CoreBundle/Resources/config/form_types.xml
@@ -23,7 +23,12 @@
             <tag name="form.type" alias="sonata_type_datetime_range"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_picker" class="Sonata\CoreBundle\Form\Type\DatePickerType" public="true">
+        <service id="sonata.core.form.type.date_picker_legacy" class="Sonata\CoreBundle\Form\Type\DatePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_date_picker"/>
+            <argument type="service" id="sonata.core.date.moment_format_converter"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.date_picker" class="Sonata\Form\Type\DatePickerType" public="true">
             <tag name="form.type" alias="sonata_type_date_picker"/>
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>


### PR DESCRIPTION
## Subject

When the form registry does not find an extension, it will try to
instantiate the type without any arguments. Adding this service definition
should let the type be found through the DependencyInjectionExtension, which
relies on the FormPass to register services, which in turn seems to
use what is written in the service definition verbatim.
See https://github.com/symfony/symfony/blob/562448ad241889af0a116bcf0a9d8ddea9126545/src/Symfony/Component/Form/FormRegistry.php#L92
See https://github.com/symfony/symfony/blob/562448ad241889af0a116bcf0a9d8ddea9126545/src/Symfony/Component/Form/DependencyInjection/FormPass.php#L73

Fixes #625

I am targeting this branch, because this is BC.

## Changelog

```markdown
### Fixed
- crashes about DatePickerType
```

## To do
    
- [ ] test this on a real project
- [ ] if it works, do the same for the other types

Deprecations shall be added in a later PR, but this should stay patch.

## How can I test this?

```shell
composer config repositories.greg vcs https://github.com/greg0ire/SonataCoreBundle
composer require sonata-project/core-bundle "dev-add_missing_service_definition as 3.13.42"
```

@axzx , @pribeirojtm, @karelVanGeerdeghom  please test this