### PR TITLE
Added new form services

### DIFF
--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\BooleanType::class, false)) {
  */
 class BooleanType extends \Sonata\Form\Type\BooleanType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_boolean_legacy';
     }

--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\BooleanType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\BooleanType::class,
-    __NAMESPACE__.'\BooleanType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class BooleanType extends \Sonata\Form\Type\BooleanType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class BooleanType extends \Sonata\Form\Type\BooleanType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_boolean_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\CollectionType::class, false)) {
  */
 class CollectionType extends \Sonata\Form\Type\CollectionType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_collection_legacy';
     }

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\CollectionType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\CollectionType::class,
-    __NAMESPACE__.'\CollectionType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class CollectionType extends \Sonata\Form\Type\CollectionType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class CollectionType extends \Sonata\Form\Type\CollectionType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_collection_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/DatePickerType.php
+++ b/src/CoreBundle/Form/Type/DatePickerType.php
@@ -22,7 +22,7 @@ namespace Sonata\CoreBundle\Form\Type;
  */
 class DatePickerType extends \Sonata\Form\Type\DatePickerType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_date_picker_legacy';
     }

--- a/src/CoreBundle/Form/Type/DatePickerType.php
+++ b/src/CoreBundle/Form/Type/DatePickerType.php
@@ -22,4 +22,8 @@ namespace Sonata\CoreBundle\Form\Type;
  */
 class DatePickerType extends \Sonata\Form\Type\DatePickerType
 {
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_date_picker_legacy';
+    }
 }

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\DateRangePickerType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\DateRangePickerType::class,
-    __NAMESPACE__.'\DateRangePickerType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_date_range_picker_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\DateRangePickerType::class, false)) {
  */
 class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_date_range_picker_legacy';
     }

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\DateRangeType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\DateRangeType::class,
-    __NAMESPACE__.'\DateRangeType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class DateRangeType extends \Sonata\Form\Type\DateRangeType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class DateRangeType extends \Sonata\Form\Type\DateRangeType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_date_range_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\DateRangeType::class, false)) {
  */
 class DateRangeType extends \Sonata\Form\Type\DateRangeType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_date_range_legacy';
     }

--- a/src/CoreBundle/Form/Type/DateTimePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimePickerType.php
@@ -22,4 +22,8 @@ namespace Sonata\CoreBundle\Form\Type;
  */
 class DateTimePickerType extends \Sonata\Form\Type\DateTimePickerType
 {
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_datetime_picker_legacy';
+    }
 }

--- a/src/CoreBundle/Form/Type/DateTimePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimePickerType.php
@@ -22,7 +22,7 @@ namespace Sonata\CoreBundle\Form\Type;
  */
 class DateTimePickerType extends \Sonata\Form\Type\DateTimePickerType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_datetime_picker_legacy';
     }

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\DateTimeRangePickerType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\DateTimeRangePickerType::class,
-    __NAMESPACE__.'\DateTimeRangePickerType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_datetime_range_picker_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\DateTimeRangePickerType::class, false)) {
  */
 class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_datetime_range_picker_legacy';
     }

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\DateTimeRangeType::class, false)) {
  */
 class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_datetime_range_legacy';
     }

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\DateTimeRangeType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\DateTimeRangeType::class,
-    __NAMESPACE__.'\DateTimeRangeType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_datetime_range_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\EqualType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\EqualType::class,
-    __NAMESPACE__.'\EqualType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class EqualType extends \Sonata\Form\Type\EqualType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class EqualType extends \Sonata\Form\Type\EqualType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_equal_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\EqualType::class, false)) {
  */
 class EqualType extends \Sonata\Form\Type\EqualType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_equal_legacy';
     }

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -19,16 +19,13 @@ if (!class_exists(\Sonata\Form\Type\ImmutableArrayType::class, false)) {
     );
 }
 
-class_alias(
-    \Sonata\Form\Type\ImmutableArrayType::class,
-    __NAMESPACE__.'\ImmutableArrayType'
-);
-
-if (false) {
-    /**
-     * @deprecated Since version 3.x, to be removed in 4.0.
-     */
-    class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
+/**
+ * @deprecated Since version 3.x, to be removed in 4.0.
+ */
+class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
+{
+    public function getBlockPrefix()
     {
+        return 'sonata_type_immutable_array_legacy';
     }
 }

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -24,7 +24,7 @@ if (!class_exists(\Sonata\Form\Type\ImmutableArrayType::class, false)) {
  */
 class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
 {
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'sonata_type_immutable_array_legacy';
     }

--- a/src/CoreBundle/Resources/config/form_types.xml
+++ b/src/CoreBundle/Resources/config/form_types.xml
@@ -1,56 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.form.type.array" class="Sonata\CoreBundle\Form\Type\ImmutableArrayType" public="true">
-            <tag name="form.type" alias="sonata_type_immutable_array"/>
+        <service id="sonata.core.form.type.array_legacy" class="Sonata\CoreBundle\Form\Type\ImmutableArrayType" public="true">
+            <tag name="form.type" alias="sonata_type_immutable_array_legacy"/>
         </service>
-        <service id="sonata.core.form.type.boolean" class="Sonata\CoreBundle\Form\Type\BooleanType" public="true">
-            <tag name="form.type" alias="sonata_type_boolean"/>
+        <service id="sonata.core.form.type.boolean_legacy" class="Sonata\CoreBundle\Form\Type\BooleanType" public="true">
+            <tag name="form.type" alias="sonata_type_boolean_legacy"/>
         </service>
-        <service id="sonata.core.form.type.collection" class="Sonata\CoreBundle\Form\Type\CollectionType" public="true">
-            <tag name="form.type" alias="sonata_type_collection"/>
+        <service id="sonata.core.form.type.collection_legacy" class="Sonata\CoreBundle\Form\Type\CollectionType" public="true">
+            <tag name="form.type" alias="sonata_type_collection_legacy"/>
         </service>
         <service id="sonata.core.form.type.translatable_choice" class="Sonata\CoreBundle\Form\Type\TranslatableChoiceType" public="true">
             <deprecated>The "%service_id%" service is deprecated since 2.2.0 and will be removed in 4.0.</deprecated>
             <tag name="form.type" alias="sonata_type_translatable_choice"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range" class="Sonata\CoreBundle\Form\Type\DateRangeType" public="true">
-            <tag name="form.type" alias="sonata_type_date_range"/>
+        <service id="sonata.core.form.type.date_range_legacy" class="Sonata\CoreBundle\Form\Type\DateRangeType" public="true">
+            <tag name="form.type" alias="sonata_type_date_range_legacy"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range" class="Sonata\CoreBundle\Form\Type\DateTimeRangeType" public="true">
-            <tag name="form.type" alias="sonata_type_datetime_range"/>
+        <service id="sonata.core.form.type.datetime_range_legacy" class="Sonata\CoreBundle\Form\Type\DateTimeRangeType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_range_legacy"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_picker" class="Sonata\CoreBundle\Form\Type\DatePickerType" public="true">
-            <tag name="form.type" alias="sonata_type_date_picker"/>
+        <service id="sonata.core.form.type.date_picker_legacy" class="Sonata\CoreBundle\Form\Type\DatePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_date_picker_legacy"/>
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_picker" class="Sonata\CoreBundle\Form\Type\DateTimePickerType" public="true">
-            <tag name="form.type" alias="sonata_type_datetime_picker"/>
+        <service id="sonata.core.form.type.datetime_picker_legacy" class="Sonata\CoreBundle\Form\Type\DateTimePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_picker_legacy"/>
             <argument type="service" id="sonata.core.date.moment_format_converter"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.date_range_picker" class="Sonata\CoreBundle\Form\Type\DateRangePickerType" public="true">
-            <tag name="form.type" alias="sonata_type_date_range_picker"/>
+        <service id="sonata.core.form.type.date_range_picker_legacy" class="Sonata\CoreBundle\Form\Type\DateRangePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_date_range_picker_legacy"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\CoreBundle\Form\Type\DateTimeRangePickerType" public="true">
-            <tag name="form.type" alias="sonata_type_datetime_range_picker"/>
+        <service id="sonata.core.form.type.datetime_range_picker_legacy" class="Sonata\CoreBundle\Form\Type\DateTimeRangePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_range_picker_legacy"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.core.form.type.equal" class="Sonata\CoreBundle\Form\Type\EqualType" public="true">
-            <tag name="form.type" alias="sonata_type_equal"/>
+        <service id="sonata.core.form.type.equal_legacy" class="Sonata\CoreBundle\Form\Type\EqualType" public="true">
+            <tag name="form.type" alias="sonata_type_equal_legacy"/>
             <argument type="service" id="translator"/>
         </service>
         <service id="sonata.core.form.type.color_selector" class="Sonata\CoreBundle\Form\Type\ColorSelectorType" public="true">
             <deprecated>The "%service_id%" service is deprecated since 3.5 and will be removed in 4.0.</deprecated>
             <tag name="form.type" alias="sonata_type_color_selector"/>
         </service>
-        <service id="sonata.core.form.type.color" class="Sonata\CoreBundle\Form\Type\ColorType" public="true">
+        <service id="sonata.core.form.type.color_legacy" class="Sonata\CoreBundle\Form\Type\ColorType" public="true">
             <tag name="form.type" alias="sonata_type_color"/>
+        </service>
+        <service id="sonata.core.form.type.array" class="Sonata\Form\ImmutableArrayType" public="true">
+            <tag name="form.type" alias="sonata_type_immutable_array"/>
+        </service>
+        <service id="sonata.core.form.type.boolean" class="Sonata\Form\BooleanType" public="true">
+            <tag name="form.type" alias="sonata_type_boolean"/>
+        </service>
+        <service id="sonata.core.form.type.collection" class="Sonata\Form\CollectionType" public="true">
+            <tag name="form.type" alias="sonata_type_collection"/>
+        </service>
+        <service id="sonata.core.form.type.date_range" class="Sonata\Form\DateRangeType" public="true">
+            <tag name="form.type" alias="sonata_type_date_range"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.datetime_range" class="Sonata\Form\DateTimeRangeType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_range"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.date_picker" class="Sonata\Form\DatePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_date_picker"/>
+            <argument type="service" id="sonata.core.date.moment_format_converter"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.datetime_picker" class="Sonata\Form\DateTimePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_picker"/>
+            <argument type="service" id="sonata.core.date.moment_format_converter"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.date_range_picker" class="Sonata\Form\DateRangePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_date_range_picker"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.datetime_range_picker" class="Sonata\Form\DateTimeRangePickerType" public="true">
+            <tag name="form.type" alias="sonata_type_datetime_range_picker"/>
+            <argument type="service" id="translator"/>
+        </service>
+        <service id="sonata.core.form.type.equal" class="Sonata\Form\EqualType" public="true">
+            <tag name="form.type" alias="sonata_type_equal"/>
+            <argument type="service" id="translator"/>
         </service>
     </services>
 </container>

--- a/src/Form/Type/BaseDoctrineORMSerializationType.php
+++ b/src/Form/Type/BaseDoctrineORMSerializationType.php
@@ -163,5 +163,3 @@ class BaseDoctrineORMSerializationType extends AbstractType
         ]);
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\BaseDoctrineORMSerializationType::class);

--- a/src/Form/Type/BasePickerType.php
+++ b/src/Form/Type/BasePickerType.php
@@ -170,5 +170,3 @@ abstract class BasePickerType extends AbstractType
         ];
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\BasePickerType::class);

--- a/src/Form/Type/BaseStatusType.php
+++ b/src/Form/Type/BaseStatusType.php
@@ -111,5 +111,3 @@ abstract class BaseStatusType extends AbstractType
         ]);
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\BaseStatusType::class);

--- a/src/Form/Type/BooleanType.php
+++ b/src/Form/Type/BooleanType.php
@@ -98,5 +98,3 @@ class BooleanType extends AbstractType
         return 'sonata_type_boolean';
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\BooleanType::class);

--- a/src/Form/Type/CollectionType.php
+++ b/src/Form/Type/CollectionType.php
@@ -72,5 +72,3 @@ class CollectionType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\CollectionType::class);

--- a/src/Form/Type/DateRangePickerType.php
+++ b/src/Form/Type/DateRangePickerType.php
@@ -42,5 +42,3 @@ class DateRangePickerType extends DateRangeType
         return $this->getBlockPrefix();
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\DateRangePickerType::class);

--- a/src/Form/Type/DateRangeType.php
+++ b/src/Form/Type/DateRangeType.php
@@ -100,5 +100,3 @@ class DateRangeType extends AbstractType
         ]);
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\DateRangeType::class);

--- a/src/Form/Type/DateTimeRangePickerType.php
+++ b/src/Form/Type/DateTimeRangePickerType.php
@@ -42,5 +42,3 @@ class DateTimeRangePickerType extends DateTimeRangeType
         return $this->getBlockPrefix();
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\DateTimeRangePickerType::class);

--- a/src/Form/Type/DateTimeRangeType.php
+++ b/src/Form/Type/DateTimeRangeType.php
@@ -100,5 +100,3 @@ class DateTimeRangeType extends AbstractType
         ]);
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\DateTimeRangeType::class);

--- a/src/Form/Type/EqualType.php
+++ b/src/Form/Type/EqualType.php
@@ -95,5 +95,3 @@ class EqualType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\EqualType::class);

--- a/src/Form/Type/ImmutableArrayType.php
+++ b/src/Form/Type/ImmutableArrayType.php
@@ -80,5 +80,3 @@ class ImmutableArrayType extends AbstractType
         return $this->getBlockPrefix();
     }
 }
-
-class_exists(\Sonata\CoreBundle\Form\Type\ImmutableArrayType::class);

--- a/tests/CoreBundle/Form/Type/DatePickerTypeTest.php
+++ b/tests/CoreBundle/Form/Type/DatePickerTypeTest.php
@@ -64,7 +64,7 @@ class DatePickerTypeTest extends TypeTestCase
     {
         $type = new DatePickerType(new MomentFormatConverter(), $this->createMock(TranslatorInterface::class));
 
-        $this->assertSame('sonata_type_date_picker', $type->getName());
+        $this->assertSame('sonata_type_date_picker_legacy', $type->getName());
     }
 
     /**
@@ -74,7 +74,7 @@ class DatePickerTypeTest extends TypeTestCase
     {
         $type = new DatePickerType(new MomentFormatConverter());
 
-        $this->assertSame('sonata_type_date_picker', $type->getName());
+        $this->assertSame('sonata_type_date_picker_legacy', $type->getName());
     }
 
     public function testSubmitValidData()

--- a/tests/CoreBundle/Form/Type/DateRangePickerTypeTest.php
+++ b/tests/CoreBundle/Form/Type/DateRangePickerTypeTest.php
@@ -58,7 +58,7 @@ class DateRangePickerTypeTest extends TypeTestCase
     {
         $type = new DateRangePickerType($this->createMock(TranslatorInterface::class));
 
-        $this->assertSame('sonata_type_date_range_picker', $type->getName());
+        $this->assertSame('sonata_type_date_range_picker_legacy', $type->getName());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/tests/CoreBundle/Form/Type/DateRangeTypeTest.php
+++ b/tests/CoreBundle/Form/Type/DateRangeTypeTest.php
@@ -58,7 +58,7 @@ class DateRangeTypeTest extends TypeTestCase
     {
         $type = new DateRangeType($this->createMock(TranslatorInterface::class));
 
-        $this->assertSame('sonata_type_date_range', $type->getName());
+        $this->assertSame('sonata_type_date_range_legacy', $type->getName());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/tests/CoreBundle/Form/Type/DateTimePickerTypeTest.php
+++ b/tests/CoreBundle/Form/Type/DateTimePickerTypeTest.php
@@ -68,7 +68,7 @@ class DateTimePickerTypeTest extends TypeTestCase
     {
         $type = new DateTimePickerType(new MomentFormatConverter(), $this->createMock(TranslatorInterface::class));
 
-        $this->assertSame('sonata_type_datetime_picker', $type->getName());
+        $this->assertSame('sonata_type_datetime_picker_legacy', $type->getName());
     }
 
     /**
@@ -78,7 +78,7 @@ class DateTimePickerTypeTest extends TypeTestCase
     {
         $type = new DateTimePickerType(new MomentFormatConverter());
 
-        $this->assertSame('sonata_type_datetime_picker', $type->getName());
+        $this->assertSame('sonata_type_datetime_picker_legacy', $type->getName());
     }
 
     public function testSubmitUnmatchingDateFormat()

--- a/tests/CoreBundle/Form/Type/DateTimeRangePickerTypeTest.php
+++ b/tests/CoreBundle/Form/Type/DateTimeRangePickerTypeTest.php
@@ -58,7 +58,7 @@ class DateTimeRangePickerTypeTest extends TypeTestCase
     {
         $type = new DateTimeRangePickerType($this->createMock(TranslatorInterface::class));
 
-        $this->assertSame('sonata_type_datetime_range_picker', $type->getName());
+        $this->assertSame('sonata_type_datetime_range_picker_legacy', $type->getName());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());
 

--- a/tests/CoreBundle/Form/Type/EqualTypeTest.php
+++ b/tests/CoreBundle/Form/Type/EqualTypeTest.php
@@ -65,7 +65,7 @@ class EqualTypeTest extends TypeTestCase
 
         $type = new EqualType($mock);
 
-        $this->assertSame('sonata_type_equal', $type->getName());
+        $this->assertSame('sonata_type_equal_legacy', $type->getName());
         $this->assertSame(ChoiceType::class, $type->getParent());
 
         FormHelper::configureOptions($type, $resolver = new OptionsResolver());

--- a/tests/CoreBundle/Form/Type/ImmutableArrayTypeTest.php
+++ b/tests/CoreBundle/Form/Type/ImmutableArrayTypeTest.php
@@ -59,7 +59,7 @@ class ImmutableArrayTypeTest extends TypeTestCase
     {
         $type = new ImmutableArrayType();
 
-        $this->assertSame('sonata_type_immutable_array', $type->getName());
+        $this->assertSame('sonata_type_immutable_array_legacy', $type->getName());
 
         $this->assertSame(version_compare(Kernel::VERSION, '2.8', '<') ? 'form' : FormType::class, $type->getParent());
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The new form services were missing, so symfony can't find the dependencies of the new forms.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #625 #626

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new form services
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
