### PR TITLE
Add missing interface autoload

### DIFF
--- a/src/Twig/Status/StatusClassRendererInterface.php
+++ b/src/Twig/Status/StatusClassRendererInterface.php
@@ -37,3 +37,5 @@ interface StatusClassRendererInterface
      */
     public function getStatusClass($object, $statusName = null, $default = '');
 }
+
+interface_exists(\Sonata\CoreBundle\Component\Status\StatusClassRendererInterface::class);


### PR DESCRIPTION

## Subject

This one slipped through during the last bugfix, not sure why.

I am targeting this branch, because this is BC.

Fixes #600

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash about new `FlashManager` class not implementing old `StatusClassRendererInterface`
```