### PR TITLE
Add missing trick to appear in the classmap

### DIFF
--- a/src/CoreBundle/Model/PageableManagerInterface.php
+++ b/src/CoreBundle/Model/PageableManagerInterface.php
@@ -23,3 +23,9 @@ class_alias(
     \Sonata\Doctrine\Model\PageableManagerInterface::class,
     __NAMESPACE__.'\PageableManagerInterface'
 );
+
+if (false) {
+    interface PageableManagerInterface extends \Sonata\Doctrine\Model\PageableManagerInterface
+    {
+    }
+}


### PR DESCRIPTION

## Subject

This should have been part of 9a3d73acfcac1104c33cda810eedfedea2a7b7ba

I am targeting this branch, because this is BC.

The issue was reported by @silasjoisten on  Slack : https://symfony-devs.slack.com/archives/C3GC7MKM5/p1545237729224800

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash about `PageableManagerInterface` when using `composer install --authoritative-classmap`
```

## How to reproduce

```
cd /tmp
git clone git@github.com:sonata-project/SonataUserBundle.git
cd SonataUserBundle
composer install --classmap-authoritative
php -r "require 'vendor/autoload.php'; require 'src/Model/UserManagerInterface.php';"
```

## How to test

```
cd /tmp
git clone git@github.com:sonata-project/SonataUserBundle.git
cd SonataUserBundle
composer config repositories.greg vcs https://github.com/greg0ire/SonataCoreBundle
composer require sonata-project/core-bundle "dev-forgotten_classmap_tricks as 3.13.42" --classmap-authoritative
php -r "require 'vendor/autoload.php'; require 'src/Model/UserManagerInterface.php';"
```