### PR TITLE
Drop old versions of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "cocur/slugify": "^1.4 || ^2.0 || ^3.0",
         "sonata-project/datagrid-bundle": "^2.0",
         "sonata-project/doctrine-extensions": "^1.1",


### PR DESCRIPTION
## Subject
I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for php 5 and php 7.0
```
