### PR TITLE
Invert condition

### DIFF
--- a/src/CoreBundle/Model/ManagerInterface.php
+++ b/src/CoreBundle/Model/ManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Model;
 
-if (interface_exists(\Sonata\Doctrine\Model\ManagerInterface::class, false)) {
+if (!interface_exists(\Sonata\Doctrine\Model\ManagerInterface::class, false)) {
     @trigger_error(
         'The '.__NAMESPACE__.'\ManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
         .' Use Sonata\Doctrine\Model\ManagerInterface instead.',

--- a/src/CoreBundle/Model/PageableManagerInterface.php
+++ b/src/CoreBundle/Model/PageableManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Model;
 
-if (interface_exists(\Sonata\Doctrine\Model\PageableManagerInterface::class, false)) {
+if (!interface_exists(\Sonata\Doctrine\Model\PageableManagerInterface::class, false)) {
     @trigger_error(
         'The '.__NAMESPACE__.'\PageableManagerInterface class is deprecated since version 3.x and will be removed in 4.0.'
         .' Use Sonata\DatagridBundle\Pager\PageableInterface instead.',


### PR DESCRIPTION
## Subject

If the type exists, then we might be triggerring the autoload from it,
and that should not trigger a deprecation.

I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation wrongly triggered when using the new interface
```
