### PR TITLE
Use new exporter namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "twig/extensions": "^1.5",
         "twig/twig": "^1.34 || ^2.0"
     },
+    "conflict": {
+        "sonata-project/exporter": "< 1.11.0"
+    },
     "require-dev": {
         "doctrine/orm": "^2.4",
         "doctrine/phpcr-odm": "^1.0",
@@ -46,7 +49,7 @@
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "nelmio/api-doc-bundle": "^2.11",
-        "sonata-project/exporter": "^1.3",
+        "sonata-project/exporter": "^1.11.0 || ^2.0",
         "symfony/phpunit-bridge": "^4.2"
     },
     "config": {

--- a/src/CoreBundle/Exporter/Exporter.php
+++ b/src/CoreBundle/Exporter/Exporter.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Exporter;
 
-use Exporter\Handler;
-use Exporter\Source\SourceIteratorInterface;
-use Exporter\Writer\CsvWriter;
-use Exporter\Writer\JsonWriter;
-use Exporter\Writer\XlsWriter;
-use Exporter\Writer\XmlWriter;
+use Sonata\Exporter\Handler;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+use Sonata\Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Writer\JsonWriter;
+use Sonata\Exporter\Writer\XlsWriter;
+use Sonata\Exporter\Writer\XmlWriter;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 @trigger_error(
     'The '.__NAMESPACE__.'\Exporter class is deprecated since version 3.1 and will be removed in 4.0.'.
-    ' Use Exporter\Exporter instead',
+    ' Use Sonata\Exporter\Exporter instead',
     E_USER_DEPRECATED
 );
 

--- a/tests/CoreBundle/Exporter/ExporterTest.php
+++ b/tests/CoreBundle/Exporter/ExporterTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Tests\Exporter;
 
-use Exporter\Source\ArraySourceIterator;
-use Exporter\Source\SourceIteratorInterface;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Exporter\Exporter;
+use Sonata\Exporter\Source\ArraySourceIterator;
+use Sonata\Exporter\Source\SourceIteratorInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**


### PR DESCRIPTION
This fixes a crash when using sonata-project/exporter 2 (nothing
currently prevents people from installing it).

## Subject

I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- crash caused by an incompatibilty with sonata-project/exporter 2
```