### PR TITLE
Move deprecation notices on buildForm methods

### DIFF
--- a/src/CoreBundle/Form/Type/BooleanType.php
+++ b/src/CoreBundle/Form/Type/BooleanType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\BooleanType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\BooleanType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\BooleanType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class BooleanType extends \Sonata\Form\Type\BooleanType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\BooleanType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\BooleanType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_boolean_legacy';

--- a/src/CoreBundle/Form/Type/CollectionType.php
+++ b/src/CoreBundle/Form/Type/CollectionType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\CollectionType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\CollectionType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\CollectionType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class CollectionType extends \Sonata\Form\Type\CollectionType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\CollectionType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\CollectionType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_collection_legacy';

--- a/src/CoreBundle/Form/Type/ColorSelectorType.php
+++ b/src/CoreBundle/Form/Type/ColorSelectorType.php
@@ -16,14 +16,9 @@ namespace Sonata\CoreBundle\Form\Type;
 use Sonata\CoreBundle\Color\Colors;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
-@trigger_error(
-    'The '.__NAMESPACE__.'\ColorSelectorType class is deprecated since version 3.5 and will be removed in 4.0.'
-    .' Use '.__NAMESPACE__.'\ColorType instead.',
-    E_USER_DEPRECATED
-);
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -32,6 +27,17 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class ColorSelectorType extends AbstractType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\ColorSelectorType class is deprecated since version 3.5 and will be removed in 4.0.'
+            .' Use '.__NAMESPACE__.'\ColorType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     /**
      * {@inheritdoc}
      *

--- a/src/CoreBundle/Form/Type/ColorType.php
+++ b/src/CoreBundle/Form/Type/ColorType.php
@@ -15,14 +15,7 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-
-if (class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\ColorType class is deprecated since version 3.10 and will be removed in 4.0.'
-        .' Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -31,6 +24,18 @@ if (class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
  */
 final class ColorType extends AbstractType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if (class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
+            @trigger_error(
+                'The '.__NAMESPACE__.'\ColorType class is deprecated since version 3.10 and will be removed in 4.0.'.' Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getParent()
     {
         return TextType::class;

--- a/src/CoreBundle/Form/Type/DatePickerType.php
+++ b/src/CoreBundle/Form/Type/DatePickerType.php
@@ -13,17 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DatePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DatePickerType instead.',
-    E_USER_DEPRECATED
-);
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DatePickerType extends \Sonata\Form\Type\DatePickerType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DatePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DatePickerType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_date_picker_legacy';

--- a/src/CoreBundle/Form/Type/DateRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateRangePickerType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\DateRangePickerType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\DateRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\DateRangePickerType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DateRangePickerType extends \Sonata\Form\Type\DateRangePickerType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DateRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DateRangePickerType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_date_range_picker_legacy';

--- a/src/CoreBundle/Form/Type/DateRangeType.php
+++ b/src/CoreBundle/Form/Type/DateRangeType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\DateRangeType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\DateRangeType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\DateRangeType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DateRangeType extends \Sonata\Form\Type\DateRangeType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DateRangeType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DateRangeType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_date_range_legacy';

--- a/src/CoreBundle/Form/Type/DateTimePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimePickerType.php
@@ -13,17 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\DateTimePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use Sonata\Form\Type\DateTimePickerType instead.',
-    E_USER_DEPRECATED
-);
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DateTimePickerType extends \Sonata\Form\Type\DateTimePickerType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DateTimePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DateTimePickerType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_datetime_picker_legacy';

--- a/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangePickerType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\DateTimeRangePickerType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\DateTimeRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\DateTimeRangePickerType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DateTimeRangePickerType extends \Sonata\Form\Type\DateTimeRangePickerType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DateTimeRangePickerType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DateTimeRangePickerType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_datetime_range_picker_legacy';

--- a/src/CoreBundle/Form/Type/DateTimeRangeType.php
+++ b/src/CoreBundle/Form/Type/DateTimeRangeType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\DateTimeRangeType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\DateTimeRangeType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\DateTimeRangeType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class DateTimeRangeType extends \Sonata\Form\Type\DateTimeRangeType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\DateTimeRangeType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\DateTimeRangeType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_datetime_range_legacy';

--- a/src/CoreBundle/Form/Type/EqualType.php
+++ b/src/CoreBundle/Form/Type/EqualType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\EqualType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\EqualType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\EqualType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class EqualType extends \Sonata\Form\Type\EqualType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\EqualType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\EqualType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_equal_legacy';

--- a/src/CoreBundle/Form/Type/ImmutableArrayType.php
+++ b/src/CoreBundle/Form/Type/ImmutableArrayType.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Form\Type;
 
-if (!class_exists(\Sonata\Form\Type\ImmutableArrayType::class, false)) {
-    @trigger_error(
-        'The '.__NAMESPACE__.'\ImmutableArrayType class is deprecated since version 3.x and will be removed in 4.0.'
-        .' Use Sonata\Form\Type\ImmutableArrayType instead.',
-        E_USER_DEPRECATED
-    );
-}
+use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * @deprecated Since version 3.x, to be removed in 4.0.
  */
 class ImmutableArrayType extends \Sonata\Form\Type\ImmutableArrayType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            'The '.__NAMESPACE__.'\ImmutableArrayType class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use Sonata\Form\Type\ImmutableArrayType instead.',
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
+    }
+
     public function getName()
     {
         return 'sonata_type_immutable_array_legacy';

--- a/src/CoreBundle/Form/Type/TranslatableChoiceType.php
+++ b/src/CoreBundle/Form/Type/TranslatableChoiceType.php
@@ -15,21 +15,12 @@ namespace Sonata\CoreBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-
-@trigger_error(
-    sprintf(
-        'Form type "%s" is deprecated since SonataCoreBundle 2.2.0 and will be'
-        .' removed in 4.0. Use form type "%s" with "translation_domain" option instead.',
-        TranslatableChoiceType::class,
-        ChoiceType::class
-    ),
-    E_USER_DEPRECATED
-);
 
 /**
  * NEXT_MAJOR: remove this class.
@@ -64,6 +55,21 @@ class TranslatableChoiceType extends AbstractType
         $resolver->setDefaults([
             'catalogue' => 'messages',
         ]);
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        @trigger_error(
+            sprintf(
+                'Form type "%s" is deprecated since SonataCoreBundle 2.2.0 and will be'
+                .' removed in 4.0. Use form type "%s" with "translation_domain" option instead.',
+                TranslatableChoiceType::class,
+                ChoiceType::class
+            ),
+            E_USER_DEPRECATED
+        );
+
+        parent::buildForm($builder, $options);
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/src/CoreBundle/Form/Type/TranslatableChoiceType.php
+++ b/src/CoreBundle/Form/Type/TranslatableChoiceType.php
@@ -63,7 +63,7 @@ class TranslatableChoiceType extends AbstractType
             sprintf(
                 'Form type "%s" is deprecated since SonataCoreBundle 2.2.0 and will be'
                 .' removed in 4.0. Use form type "%s" with "translation_domain" option instead.',
-                TranslatableChoiceType::class,
+                self::class,
                 ChoiceType::class
             ),
             E_USER_DEPRECATED

--- a/tests/CoreBundle/Form/Type/ColorTypeTest.php
+++ b/tests/CoreBundle/Form/Type/ColorTypeTest.php
@@ -32,11 +32,19 @@ class ColorTypeTest extends TypeTestCase
             $this->markTestSkipped('< Symfony 3.4');
         }
 
-        $type = new ColorType();
+        $this->factory->create(ColorType::class);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\CoreBundle\Form\Type\ColorType class is deprecated since version 3.10 and will be removed in 4.0. Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.
+     */
     public function testBuildForm()
     {
+        if (!class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
+            $this->markTestSkipped('< Symfony 3.4');
+        }
+
         $formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $formBuilder
             ->expects($this->any())
@@ -51,8 +59,16 @@ class ColorTypeTest extends TypeTestCase
         $type->buildForm($formBuilder, []);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\CoreBundle\Form\Type\ColorType class is deprecated since version 3.10 and will be removed in 4.0. Use Symfony\Component\Form\Extension\Core\Type\ColorType instead.
+     */
     public function testSubmitValidData()
     {
+        if (!class_exists('Symfony\Component\Form\Extension\Core\Type\ColorType')) {
+            $this->markTestSkipped('< Symfony 3.4');
+        }
+
         $form = $this->factory->create(ColorType::class);
         $form->submit('#556b2f');
         $this->assertTrue($form->isSynchronized());


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is BC. It moves deprecation notices of `Sonata\CoreBundle\Form\Type\*` classes into their buildForm methods.

Closes #580 

## Changelog

```markdown
### Changed
- Moved deprecation notices of `Sonata\CoreBundle\Form\Type\*` classes into their buildForm methods
```
