### PR TITLE
added grouped flash messages template

### DIFF
--- a/src/CoreBundle/Resources/translations/SonataCoreBundle.de.xliff
+++ b/src/CoreBundle/Resources/translations/SonataCoreBundle.de.xliff
@@ -602,6 +602,18 @@
                 <source>message_close</source>
                 <target>Schließen</target>
             </trans-unit>
+            <trans-unit id="success">
+                <source>success</source>
+                <target>Erfolgreich</target>
+            </trans-unit>
+            <trans-unit id="warning">
+                <source>warning</source>
+                <target>Warnung</target>
+            </trans-unit>
+            <trans-unit id="danger">
+                <source>danger</source>
+                <target>Fehlgeschlagen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/translations/SonataCoreBundle.en.xliff
+++ b/src/CoreBundle/Resources/translations/SonataCoreBundle.en.xliff
@@ -602,6 +602,18 @@
                 <source>message_close</source>
                 <target>Close</target>
             </trans-unit>
+            <trans-unit id="success">
+                <source>success</source>
+                <target>Success</target>
+            </trans-unit>
+            <trans-unit id="warning">
+                <source>warning</source>
+                <target>Warning</target>
+            </trans-unit>
+            <trans-unit id="danger">
+                <source>danger</source>
+                <target>Danger</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/CoreBundle/Resources/views/FlashMessage/render.html.twig
+++ b/src/CoreBundle/Resources/views/FlashMessage/render.html.twig
@@ -8,18 +8,35 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
 {% for type in sonata_flashmessages_types() %}
     {% set domain = domain is defined ? domain : null %}
-    {% for message in sonata_flashmessages_get(type, domain) %}
+    {% set messages = sonata_flashmessages_get(type, domain) %}
+    {% if messages|length > 1 %}
+        <div class="alert alert-{{ type|sonata_status_class }} alert-dismissible collapsed-box">
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true" aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">×</button>
+            <h4>
+                <button class="btn btn-link" style="color: unset; padding: 0;" data-toggle="collapse" data-target="#alert-body-{{ loop.index }}">
+                    {{ type|trans({}, 'SonataCoreBundle')|upper }}
+                    <span>&#x25BE;</span>
+                </button>
+            </h4>
+            <div id="alert-body-{{ loop.index }}" class="collapse">
+                {% for message in messages %}
+                    {{ message|raw }} </br>
+                {% endfor %}
+            </div>
+        </div>
+    {% elseif messages|length != 0 %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissable">
             <button
-                type="button"
-                class="close"
-                data-dismiss="alert"
-                aria-hidden="true"
-                aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
+                    type="button"
+                    class="close"
+                    data-dismiss="alert"
+                    aria-hidden="true"
+                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
             >&times;</button>
-            {{ message|raw }}
+            {{ messages|first|raw }}
         </div>
-    {% endfor %}
+    {% endif %}
 {% endfor %}

--- a/src/CoreBundle/Resources/views/FlashMessage/render.html.twig
+++ b/src/CoreBundle/Resources/views/FlashMessage/render.html.twig
@@ -14,9 +14,20 @@ file that was distributed with this source code.
     {% set messages = sonata_flashmessages_get(type, domain) %}
     {% if messages|length > 1 %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissible collapsed-box">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true" aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">×</button>
+            <button
+                    type="button"
+                    class="close"
+                    data-dismiss="alert"
+                    aria-hidden="true"
+                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">
+                &times;
+            </button>
             <h4>
-                <button class="btn btn-link" style="color: unset; padding: 0;" data-toggle="collapse" data-target="#alert-body-{{ loop.index }}">
+                <button
+                        class="btn btn-link"
+                        style="color: unset; padding: 0;"
+                        data-toggle="collapse"
+                        data-target="#alert-body-{{ loop.index }}">
                     {{ type|trans({}, 'SonataCoreBundle')|upper }}
                     <span>&#x25BE;</span>
                 </button>
@@ -27,15 +38,16 @@ file that was distributed with this source code.
                 {% endfor %}
             </div>
         </div>
-    {% elseif messages|length != 0 %}
+    {% elseif messages|length == 1 %}
         <div class="alert alert-{{ type|sonata_status_class }} alert-dismissable">
             <button
                     type="button"
                     class="close"
                     data-dismiss="alert"
                     aria-hidden="true"
-                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}"
-            >&times;</button>
+                    aria-label="{{ 'message_close'|trans({}, 'SonataCoreBundle') }}">
+                &times;
+            </button>
             {{ messages|first|raw }}
         </div>
     {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I am targeting this branch, because this is a bc.

Closes #507 

## Changelog
* flash message bag > 1 take grouped messaged
* otherwise take the normal template

## To do
    
- [ ] add bool flag to configuration to allow disableing
- [ ] Update the documentation
- [ ] Update Translations

## Look & Feel

### Before
<img width="1240" alt="bildschirmfoto 2019-01-16 um 20 01 58" src="https://user-images.githubusercontent.com/10114981/51272178-b3f7e780-19c9-11e9-8b33-4050178ded97.png">


### After

#### Collapsed
![bildschirmfoto 2019-01-15 um 14 09 33](https://user-images.githubusercontent.com/10114981/51182696-46679080-18cf-11e9-855b-7f2b12b8b6ba.png)

#### Expanded
![bildschirmfoto 2019-01-15 um 14 09 41](https://user-images.githubusercontent.com/10114981/51182700-4b2c4480-18cf-11e9-83b8-37ddef25c37e.png)
