### PR TITLE
fix risky tests

### DIFF
--- a/src/CoreBundle/Test/XliffValidatorTestCase.php
+++ b/src/CoreBundle/Test/XliffValidatorTestCase.php
@@ -44,6 +44,12 @@ abstract class XliffValidatorTestCase extends TestCase
         if (\count($this->errors) > 0) {
             $this->fail(sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors)));
         }
+
+        $this->assertCount(
+            0,
+            $this->errors,
+            sprintf('Unable to parse xliff files: %s', implode(', ', $this->errors))
+        );
     }
 
     /**


### PR DESCRIPTION
an alternative could be to use @doesNotPerformAssertions annotation
on this testcase but this one is more straight forward.

After merging this, only the test on `--prefer-lowest`-builds, depending on `XliffValidatorTestCase` will be marked as "risky".