### PR TITLE
Extend the TestCase class

### DIFF
--- a/tests/CoreBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/CoreBundle/DependencyInjection/ConfigurationTest.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sonata\CoreBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\DependencyInjection\Configuration;
 
-class ConfigurationTest
+class ConfigurationTest extends TestCase
 {
     use ConfigurationTestCaseTrait;
 


### PR DESCRIPTION
I was too hasty and forgot to replace the previously extended class with
this. It did not make the tests fail, that test was simply ignored,
which means the coverage should go up.