### PR TITLE
Migrate to new classes and services

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,9 @@
 UPGRADE 3.x
 ===========
 
+A new bundle named `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle`
+should be registered in the kernel of your application.
+
 The `ColorType` class is deprecated. Use 
 `Symfony\Component\Form\Extension\Core\Type\ColorType` instead.
 

--- a/src/CoreBundle/DependencyInjection/SonataCoreExtension.php
+++ b/src/CoreBundle/DependencyInjection/SonataCoreExtension.php
@@ -23,6 +23,7 @@ use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Form\Type\TranslatableChoiceType;
 use Sonata\CoreBundle\Serializer\BaseSerializerHandler;
+use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
@@ -73,6 +74,20 @@ EOT
             }
         }
         $config = $processor->processConfiguration($configuration, $configs);
+
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (!isset($bundles['SonataDoctrineBundle'])) {
+            // NEXT_MAJOR remove the alias, throw an exception
+            @trigger_error(sprintf(
+                'Not registering bundle "%s" is deprecated since 3.x, registering it will be mandatory in 4.0',
+                SonataDoctrineBundle::class
+            ), E_USER_DEPRECATED);
+            $container->setAlias(
+                'sonata.doctrine.model.adapter.chain',
+                'sonata.core.model.adapter.chain'
+            );
+        }
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('date.xml');

--- a/src/CoreBundle/Resources/config/twig.xml
+++ b/src/CoreBundle/Resources/config/twig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.core.twig.extension.wrapping" class="Sonata\CoreBundle\Twig\Extension\FormTypeExtension">
+        <service id="sonata.core.twig.extension.wrapping" class="Sonata\Twig\Extension\FormTypeExtension">
             <tag name="twig.extension"/>
             <argument>%sonata.core.form_type%</argument>
         </service>
@@ -9,20 +9,20 @@
         <service id="sonata.core.twig.extension.text" class="Sonata\CoreBundle\Twig\Extension\DeprecatedTextExtension">
             <tag name="twig.extension"/>
         </service>
-        <service id="sonata.core.twig.status_runtime" class="Sonata\CoreBundle\Twig\Extension\StatusRuntime">
+        <service id="sonata.core.twig.status_runtime" class="Sonata\Twig\Extension\StatusRuntime">
             <tag name="twig.runtime"/>
         </service>
         <service id="sonata.core.twig.status_extension" class="Sonata\CoreBundle\Twig\Extension\StatusExtension">
             <tag name="twig.extension"/>
         </service>
-        <service id="sonata.core.twig.deprecated_template_extension" class="Sonata\CoreBundle\Twig\Extension\DeprecatedTemplateExtension">
+        <service id="sonata.core.twig.deprecated_template_extension" class="Sonata\Twig\Extension\DeprecatedTemplateExtension">
             <tag name="twig.extension"/>
         </service>
-        <service id="sonata.core.twig.template_extension" class="Sonata\CoreBundle\Twig\Extension\TemplateExtension">
+        <service id="sonata.core.twig.template_extension" class="Sonata\Twig\Extension\TemplateExtension">
             <tag name="twig.extension"/>
             <argument>%kernel.debug%</argument>
             <argument type="service" id="translator"/>
-            <argument type="service" id="sonata.core.model.adapter.chain"/>
+            <argument type="service" id="sonata.doctrine.model.adapter.chain"/>
         </service>
     </services>
 </container>

--- a/tests/CoreBundle/DependencyInjection/SonataCoreExtensionTest.php
+++ b/tests/CoreBundle/DependencyInjection/SonataCoreExtensionTest.php
@@ -19,6 +19,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SonataCoreExtensionTest extends AbstractExtensionTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', ['SonataDoctrineBundle' => true]);
+    }
+
     /**
      * @group legacy
      */
@@ -75,6 +81,17 @@ class SonataCoreExtensionTest extends AbstractExtensionTestCase
 
         $extension = new SonataCoreExtension();
         $extension->prepend($containerBuilder->reveal());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not registering bundle "Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle" is deprecated since 3.x, registering it will be mandatory in 4.0
+     */
+    public function testItLoadsProperlyWithoutDoctrineBundle()
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load();
+        $this->assertContainerBuilderHasService('sonata.doctrine.model.adapter.chain');
     }
 
     protected function getContainerExtensions()


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is BC.

Refs #664 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- not registering `Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle` in the kernel of your app
### Fixed
- several deprecations about services
```

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/SonataCoreBundle
composer require sonata-project/core-bundle "dev-use-new-classes as 3.15.1"
```
