### PR TITLE
Add missing Brazilian Portuguese translations

### DIFF
--- a/src/CoreBundle/Resources/translations/SonataCoreBundle.pt_BR.xliff
+++ b/src/CoreBundle/Resources/translations/SonataCoreBundle.pt_BR.xliff
@@ -594,6 +594,18 @@
                 <source>yellowgreen</source>
                 <target>Verde amarelado</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Fechar</target>
+            </trans-unit>
+            <trans-unit id="more">
+                <source>more</source>
+                <target>Mais</target>
+            </trans-unit>
+            <trans-unit id="less">
+                <source>less</source>
+                <target>Menos</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
<!-- Describe your Pull Request content here -->
Since commit 308ef4f64205403dcefb29947b06b4953fb3b3db and c5dfef1337781fb2b1972b92b8ff8ec4f6458c86 there 3 new translation entries that were missing in Brazilian Portuguese. This commit adds them.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the translations added only exist in this branch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added translations to keys `more`, `less` and `message_close`.
```