### PR TITLE
Refer to new runtime

### DIFF
--- a/src/CoreBundle/Twig/Extension/StatusExtension.php
+++ b/src/CoreBundle/Twig/Extension/StatusExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\CoreBundle\Twig\Extension;
 
 use Sonata\CoreBundle\Component\Status\StatusClassRendererInterface;
+use Sonata\Twig\Extension\StatusRuntime;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 


### PR DESCRIPTION
The other one is no longer registered.


## Subject

I am targeting this branch, because this is BC.

Fixes #672

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- message about being unable to load the `StatusRuntime`
```


# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/SonataCoreBundle
composer require sonata-project/core-bundle "dev-refer_to_new_runtime as 3.16.0"
```
