### PR TITLE
Inject adapters on the new doctrine service name

### DIFF
--- a/src/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/src/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -24,22 +24,22 @@ class AdapterCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('sonata.core.model.adapter.chain')) {
+        if (!$container->has('sonata.doctrine.model.adapter.chain')) {
             return;
         }
 
-        $definition = $container->findDefinition('sonata.core.model.adapter.chain');
+        $definition = $container->findDefinition('sonata.doctrine.model.adapter.chain');
 
         if ($container->has('doctrine')) {
-            $definition->addMethodCall('addAdapter', [new Reference('sonata.core.model.adapter.doctrine_orm')]);
+            $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_orm')]);
         } else {
-            $container->removeDefinition('sonata.core.model.adapter.doctrine_orm');
+            $container->removeDefinition('sonata.doctrine.adapter.doctrine_orm');
         }
 
         if ($container->has('doctrine_phpcr')) {
-            $definition->addMethodCall('addAdapter', [new Reference('sonata.core.model.adapter.doctrine_phpcr')]);
+            $definition->addMethodCall('addAdapter', [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]);
         } else {
-            $container->removeDefinition('sonata.core.model.adapter.doctrine_phpcr');
+            $container->removeDefinition('sonata.doctrine.adapter.doctrine_phpcr');
         }
     }
 }

--- a/tests/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -31,8 +31,8 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
 
     public function testDefinitionsAdded()
     {
-        $coreModelAdapterChain = new Definition();
-        $this->setDefinition('sonata.core.model.adapter.chain', $coreModelAdapterChain);
+        $adapterChain = new Definition();
+        $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
 
         $this->registerService('doctrine', 'foo');
         $this->registerService('doctrine_phpcr', 'foo');
@@ -40,29 +40,29 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.core.model.adapter.chain',
+            'sonata.doctrine.model.adapter.chain',
             'addAdapter',
-            [new Reference('sonata.core.model.adapter.doctrine_orm')]
+            [new Reference('sonata.doctrine.adapter.doctrine_orm')]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.core.model.adapter.chain',
+            'sonata.doctrine.model.adapter.chain',
             'addAdapter',
-            [new Reference('sonata.core.model.adapter.doctrine_phpcr')]
+            [new Reference('sonata.doctrine.adapter.doctrine_phpcr')]
         );
     }
 
     public function testDefinitionsRemoved()
     {
-        $coreModelAdapterChain = new Definition();
-        $this->setDefinition('sonata.core.model.adapter.chain', $coreModelAdapterChain);
+        $adapterChain = new Definition();
+        $this->setDefinition('sonata.doctrine.model.adapter.chain', $adapterChain);
 
-        $this->registerService('sonata.core.model.adapter.doctrine_orm', 'foo');
-        $this->registerService('sonata.core.model.adapter.doctrine_phpcr', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_orm', 'foo');
+        $this->registerService('sonata.doctrine.adapter.doctrine_phpcr', 'foo');
 
         $this->compile();
 
-        $this->assertContainerBuilderNotHasService('sonata.core.model.adapter.doctrine_orm');
-        $this->assertContainerBuilderNotHasService('sonata.core.model.adapter.doctrine_phpcr');
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.adapter.doctrine_orm');
+        $this->assertContainerBuilderNotHasService('sonata.doctrine.adapter.doctrine_phpcr');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this should be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Adapters are not being injected on the adapter chain.
- `sonata_urlsafeid` twig filter is working again
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
