### PR TITLE
Set translation domain for the form validators

### DIFF
--- a/docs/reference/conditional_validation.rst
+++ b/docs/reference/conditional_validation.rst
@@ -37,6 +37,14 @@ object. The object can be used to check assertions against the model::
 
     // ...
 
+    /* Specify the translation domain */
+    $errorElement
+        ->with('value')
+            ->addViolation('translation_key_with_{var}', ['%var%' => 'value'], null, 'translation_domain')
+        ->end();
+
+    // ...
+
     /* conditional validation */
     if ($this->getSubject()->getState() == Post::STATUS_ONLINE) {
         $errorElement

--- a/src/Form/Validator/ErrorElement.php
+++ b/src/Form/Validator/ErrorElement.php
@@ -22,6 +22,8 @@ use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionCont
 
 class ErrorElement
 {
+    private const DEFAULT_TRANSLATION_DOMAIN = 'validators';
+
     /**
      * @var LegacyExecutionContextInterface|ExecutionContextInterface
      */
@@ -174,6 +176,7 @@ class ErrorElement
      * @param string|array $message
      * @param array        $parameters
      * @param null         $value
+     * @param string       $translationDomain
      *
      * @return ErrorElement
      */
@@ -186,6 +189,15 @@ class ErrorElement
         }
 
         $subPath = (string) $this->getCurrentPropertyPath();
+        $translationDomain = self::DEFAULT_TRANSLATION_DOMAIN;
+
+        // NEXT_MAJOR: Remove this hack
+        if (\func_num_args() >= 4) {
+            $arg = func_get_arg(3);
+            if ((\is_string($arg))) {
+                $translationDomain = $arg;
+            }
+        }
 
         if ($this->context instanceof LegacyExecutionContextInterface) {
             $this->context->addViolationAt($subPath, $message, $parameters, $value);
@@ -193,6 +205,7 @@ class ErrorElement
             $this->context->buildViolation($message)
                ->atPath($subPath)
                ->setParameters($parameters)
+               ->setTranslationDomain($translationDomain)
                ->setInvalidValue($value)
                ->addViolation();
         }

--- a/tests/Form/Validator/ErrorElementTest.php
+++ b/tests/Form/Validator/ErrorElementTest.php
@@ -104,6 +104,15 @@ class ErrorElementTest extends TestCase
     /**
      * @group legacy
      */
+    public function testAddViolationWithTranslationDomain()
+    {
+        $this->errorElement->addViolation(['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR'], [], null, 'translation_domain');
+        $this->assertSame([['Foo error message', ['bar_param' => 'bar_param_lvalue'], 'BAR']], $this->errorElement->getErrors());
+    }
+
+    /**
+     * @group legacy
+     */
     public function testAddConstraint()
     {
         $constraint = new NotNull();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, to give the possibility to set a translation domain for the form validators.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Add this buildViolation()->setTranslationDomain() in ErrorElement::addViolation
- Add new parameter "$translationDomain" to ErrorElement::addViolation method
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
