### PR TITLE
Bump "twig/twig" to "^2.9" in order to replace usage of `spaceless` tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
         "twig/extensions": "^1.5",
-        "twig/twig": "^1.34 || ^2.0"
+        "twig/twig": "^2.9"
     },
     "conflict": {
         "sonata-project/exporter": "< 1.11.0"

--- a/src/CoreBundle/Resources/views/Form/color.html.twig
+++ b/src/CoreBundle/Resources/views/Form/color.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 {% block sonata_type_color_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <input type="color" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_color_widget %}

--- a/src/CoreBundle/Resources/views/Form/colorpicker.html.twig
+++ b/src/CoreBundle/Resources/views/Form/colorpicker.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 {% block sonata_type_color_selector_widget %}
     {{ block('choice_widget') }}
-    {% spaceless %}
+    {% apply spaceless %}
         <script type="text/javascript">
             jQuery(function ($) {
                 var select2FormatColorSelect = function format(state) {
@@ -29,5 +29,5 @@ file that was distributed with this source code.
                 });
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_color_selector_widget %}

--- a/src/CoreBundle/Resources/views/Form/datepicker.html.twig
+++ b/src/CoreBundle/Resources/views/Form/datepicker.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
 {% endblock sonata_type_date_picker_widget_html %}
 
 {% block sonata_type_date_picker_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if wrap_fields_with_addons %}
             <div class="input-group">
                 {{ block('sonata_type_date_picker_widget_html') }}
@@ -34,7 +34,7 @@ file that was distributed with this source code.
                 $('#{{ datepicker_use_button ? 'dp_' : '' }}{{ id }}').datetimepicker({{ dp_options|json_encode|raw }});
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_date_picker_widget %}
 
 {% block sonata_type_datetime_picker_widget_html %}
@@ -52,7 +52,7 @@ file that was distributed with this source code.
 {% endblock sonata_type_datetime_picker_widget_html %}
 
 {% block sonata_type_datetime_picker_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if wrap_fields_with_addons %}
             <div class="input-group">
                 {{ block('sonata_type_datetime_picker_widget_html') }}
@@ -65,11 +65,11 @@ file that was distributed with this source code.
                 $('#{{ datepicker_use_button ? 'dtp_' : '' }}{{ id }}').datetimepicker({{ dp_options|json_encode|raw }});
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_datetime_picker_widget %}
 
 {% block sonata_type_datetime_range_script_block %}
-    {% spaceless %}
+    {% apply spaceless %}
         {{ block('form_widget') }}
         <script type="text/javascript">
             jQuery(function ($) {
@@ -83,7 +83,7 @@ file that was distributed with this source code.
                 });
             });
         </script>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock sonata_type_datetime_range_script_block %}
 
 {% block sonata_type_datetime_range_picker_widget %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Bump "twig/twig" to "^2.9" in order to replace usages of deprecated features.

I am targeting this branch, because the changes are considered BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bumped "twig/twig" dependency to "^2.9";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter.
```

Follow up of sonata-project/SonataAdminBundle#5576.
