### PR TITLE
Sets by default the long date format on the date picker form type

### DIFF
--- a/src/Form/Type/DatePickerType.php
+++ b/src/Form/Type/DatePickerType.php
@@ -36,7 +36,7 @@ class DatePickerType extends BasePickerType
     {
         $resolver->setDefaults(array_merge($this->getCommonDefaults(), [
             'dp_pick_time' => false,
-            'format' => DateType::DEFAULT_FORMAT,
+            'format' => \IntlDateFormatter::LONG,
         ]));
 
         parent::configureOptions($resolver);


### PR DESCRIPTION
## Subject

Sets by default the long date format to allow forms in Spanish to submit dates without extra configuration. 

## Branch
I'm targeting this branch because it fixes a small issue that affects only sites with a Spanish locale and using the `DatePicker` form type when using the default or medium DateType Format. This change will not break any existing site but it will change the format used in the form fields that are not directly changed to use a different format.

## Issue
The issue being resolved was originally reported on the `SonataAdminBundle`:
https://github.com/sonata-project/SonataAdminBundle/issues/5235

## Changelog

### Changed
- Changes the default DateType format on the DatePicker form type to prevent errors when using Spanish locale.