### PR TITLE
Add deprecation note to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,9 @@
 <!--
+    WARNING:
+    This package is deprecated and only accepts bugfixes.
+-->
+
+<!--
     Before you open an issue, make sure this one does not already exist.
     Please also read the "guidelines for contributing" link above before posting.
 -->

--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,3 +1,8 @@
+<!--
+    WARNING:
+    This package is deprecated and only accepts bugfixes.
+-->
+
 ---
 name: 🐞 Bug Report
 about: Something is broken? 🔨

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,9 +1,14 @@
+<!--
+    WARNING:
+    This package is deprecated and only accepts bugfixes.
+-->
+
 ---
-name: 🚀 Feature Request
-about: I have a suggestion (and may want to implement it 🙂)!
+name: ⛔ NO feature requests
+about: This package is deprecated and isn't accepting feature requests
 labels: feature
 ---
 
-## Feature Request
-
-<!-- Provide a summary of the feature. -->
+This package is deprecated and isn't accepting feature requests. Please, try to
+find the [replacement package](https://github.com/sonata-project) which could
+match the feature you are trying to propose.

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,3 +1,8 @@
+<!--
+    WARNING:
+    This package is deprecated and only accepts bugfixes.
+-->
+
 ---
 name: ⛔ NO support questions
 about: If you have a question, please check out our Slack or StackOverflow!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
 <!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
+<!--
+    WARNING:
+    This package is deprecated and only accepts bugfixes.
+-->
 ## Subject
 
 <!-- Describe your Pull Request content here -->
@@ -28,7 +32,7 @@ Closes #{put_issue_number_here}
     please keep it short and clear and to the point
 -->
 
-<!-- 
+<!--
     If you are updating something that doesn't require
     a release, you can delete the whole Changelog section.
     (eg. update to docs, tests)
@@ -54,9 +58,9 @@ Closes #{put_issue_number_here}
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
-    
+
     ## To do
-    
+
     - [ ] Update the tests
     - [ ] Update the documentation
     - [ ] Add an upgrade note


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Add deprecation note to issue templates.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

Closes [this card](https://github.com/sonata-project/dev-kit/projects/1#card-20790337).