### PR TITLE
Update `composer.json` in order to tell that the package is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sonata-project/core-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony SonataCoreBundle",
+    "description": "Symfony SonataCoreBundle (abandoned)",
     "keywords": [
         "sonata"
     ],
@@ -52,6 +52,11 @@
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "symfony/phpunit-bridge": "^4.3"
     },
+    "suggest": {
+        "sonata-project/doctrine-extensions": "Direct replacement for Doctrine behavioral extensions",
+        "sonata-project/form-extensions": "Direct replacement for Symfony form extensions",
+        "sonata-project/twig-extensions": "Direct replacement for Twig Extensions"
+    },
     "config": {
         "sort-packages": true
     },
@@ -75,5 +80,6 @@
             "Sonata\\Serializer\\Tests\\": "tests/Serializer/",
             "Sonata\\Twig\\Tests\\": "tests/Twig/"
         }
-    }
+    },
+    "abandoned": true
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update `composer.json` in order to tell that the package is abandoned.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes [this card](https://github.com/sonata-project/dev-kit/projects/1#card-20790366).