### PR TITLE
Fixed signature of InlineConstraint::__sleep

### DIFF
--- a/src/Form/Validator/Constraints/InlineConstraint.php
+++ b/src/Form/Validator/Constraints/InlineConstraint.php
@@ -49,7 +49,7 @@ class InlineConstraint extends Constraint
         }
     }
 
-    public function __sleep()
+    public function __sleep(): array
     {
         if (!\is_string($this->service) || !\is_string($this->method)) {
             return [];


### PR DESCRIPTION
## Subject
Symfony 4.4 adds typehints throughout the codebase. The public API should remain backward-compatible. However `\Sonata\Form\Validator\Constraints\InlineConstraint` overrides the `@internal` `__sleep` method and breaks because of the change in signature. The AbstractAdmin attaches this inline constraint for each admin.

This commit works around the issue, however it still overrides an `@internal` method

I am targeting this branch, because the change should be backwards-compatible.

Closes #715

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataCoreBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Symfony 4.4 compatibility: Fixed signature of InlineConstraint::__sleep
``` 
