### PR TITLE
allow to use symfony/dependency-injection 4.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/datagrid-bundle": "^2.0",
         "sonata-project/doctrine-extensions": "^1.1",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0,!=4.4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
         "symfony/form": "^2.8.18 || ^3.2.6 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",

--- a/tests/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPassTest.php
+++ b/tests/CoreBundle/DependencyInjection/Compiler/AdapterCompilerPassTest.php
@@ -37,6 +37,7 @@ final class AdapterCompilerPassTest extends AbstractCompilerPassTestCase
         $this->registerService('doctrine', 'foo');
         $this->registerService('doctrine_phpcr', 'foo');
 
+        $this->container->getCompilerPassConfig()->setAfterRemovingPasses([]);
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(


### PR DESCRIPTION
This allow to use `SonataCoreBundle` with `symfony/dependency-injection` `4.4.0`.

See https://github.com/sonata-project/SonataCoreBundle/issues/720#issuecomment-559465617 for details about the issue.

Closes #720.