### PR TITLE
Steal Test fixture class from Twig bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/property-access": "^2.8 || ^3.2 || ^4.0",
         "symfony/security-csrf": "^2.8 || ^3.2 || ^4.0",
         "symfony/translation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0,!= 4.4.0",
+        "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
         "twig/extensions": "^1.5",
         "twig/twig": "^1.34 || ^2.0"

--- a/src/Form/Fixtures/StubFilesystemLoader.php
+++ b/src/Form/Fixtures/StubFilesystemLoader.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Fixtures;
+
+use Twig\Loader\FilesystemLoader;
+
+final class StubFilesystemLoader extends FilesystemLoader
+{
+    protected function findTemplate($name, $throw = true)
+    {
+        // strip away bundle name
+        $parts = explode(':', $name);
+
+        return parent::findTemplate(end($parts), $throw);
+    }
+}

--- a/src/Form/Fixtures/StubTranslator.php
+++ b/src/Form/Fixtures/StubTranslator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Form\Fixtures;
+
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+if (interface_exists(TranslatorInterface::class)) {
+    final class StubTranslator implements TranslatorInterface
+    {
+        public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+        {
+            return '[trans]'.strtr($id, $parameters).'[/trans]';
+        }
+    }
+} else {
+    final class StubTranslator implements LegacyTranslatorInterface
+    {
+        public function trans($id, array $parameters = [], $domain = null, $locale = null)
+        {
+            return '[trans]'.$id.'[/trans]';
+        }
+
+        public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+        {
+            return '[trans]'.$id.'[/trans]';
+        }
+
+        public function setLocale($locale)
+        {
+        }
+
+        public function getLocale()
+        {
+        }
+    }
+}

--- a/src/Form/Test/AbstractWidgetTestCase.php
+++ b/src/Form/Test/AbstractWidgetTestCase.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Form\Test;
 
+use Sonata\Form\Fixtures\StubFilesystemLoader;
+use Sonata\Form\Fixtures\StubTranslator;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
@@ -20,8 +22,6 @@ use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Form\TwigRendererEngineInterface;
 use Symfony\Bridge\Twig\Form\TwigRendererInterface;
-use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
-use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;


### PR DESCRIPTION
## Subject

The bridge archives have recently been modified so that they no longer
contain tests. We were relying on one of the fixtures that came with
thes tests. Copying the fixture to our project fixes the issue.
Allows using the twig bridge v4.4

See https://github.com/symfony/twig-bridge/commit/3b24df50a23d2a11d459d9e31dc4cffb8f7caf

I am targeting this branch, because this is BC.

Closes #722 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Compatibility with `symfony/twig-bridge` 4.4
```

