### PR TITLE
Replace deprecated ContainerAwareCommand with Command

### DIFF
--- a/src/CoreBundle/Command/SonataDumpDoctrineMetaCommand.php
+++ b/src/CoreBundle/Command/SonataDumpDoctrineMetaCommand.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sonata\CoreBundle\Command;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
 use Gaufrette\Adapter\Local as LocalAdapter;
 use Gaufrette\Filesystem;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,12 +27,24 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @deprecated since sonata-project/core-bundle 3.12.0, to be removed in 4.0.
  */
-class SonataDumpDoctrineMetaCommand extends ContainerAwareCommand
+class SonataDumpDoctrineMetaCommand extends Command
 {
+    /**
+     * @var ManagerRegistry
+     */
+    protected $doctrine;
+
     /**
      * @var array
      */
     protected $metadata;
+
+    public function __construct(ManagerRegistry $doctrine, string $name = null)
+    {
+        parent::__construct($name);
+
+        $this->doctrine = $doctrine;
+    }
 
     protected function configure()
     {
@@ -60,7 +73,7 @@ class SonataDumpDoctrineMetaCommand extends ContainerAwareCommand
                     null
                 ),
             ])
-            ->setDescription('Get information on the current Doctrine\'s schema')
+            ->setDescription('Get information on the current Doctrine\'s schema!')
         ;
     }
 
@@ -72,7 +85,7 @@ class SonataDumpDoctrineMetaCommand extends ContainerAwareCommand
         );
 
         $output->writeln('Initialising Doctrine metadata.');
-        $manager = $this->getContainer()->get('doctrine')->getManager();
+        $manager = $this->doctrine->getManager();
         $metadata = $manager->getMetadataFactory()->getAllMetadata();
 
         $allowedMeta = $this->filterMetadata($metadata, $input, $output);

--- a/src/CoreBundle/Command/SonataListFormMappingCommand.php
+++ b/src/CoreBundle/Command/SonataListFormMappingCommand.php
@@ -13,21 +13,34 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @deprecated since sonata-project/core-bundle 3.7, to be removed in 4.0, the form mapping feature should be disabled.
  */
-class SonataListFormMappingCommand extends ContainerAwareCommand
+class SonataListFormMappingCommand extends Command
 {
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
     /**
      * @var array
      */
     protected $metadata;
+
+    public function __construct(ContainerInterface $container, string $name = null)
+    {
+        parent::__construct($name);
+
+        $this->container = $container;
+    }
 
     public function isEnabled()
     {
@@ -52,9 +65,9 @@ class SonataListFormMappingCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Getting form types:');
-        foreach ($this->getContainer()->getParameter('sonata.core.form.types') as $id) {
+        foreach ($this->container->getParameter('sonata.core.form.types') as $id) {
             try {
-                $instance = $this->getContainer()->get($id);
+                $instance = $this->container->get($id);
 
                 if ('yaml' === $input->getOption('format')) {
                     $output->writeln(sprintf('              %s: %s', $instance->getName(), \get_class($instance)));
@@ -68,9 +81,9 @@ class SonataListFormMappingCommand extends ContainerAwareCommand
 
         $output->writeln("\n\n\nGetting form type extensions:");
         $types = [];
-        foreach ($this->getContainer()->getParameter('sonata.core.form.type_extensions') as $id) {
+        foreach ($this->container->getParameter('sonata.core.form.type_extensions') as $id) {
             try {
-                $instance = $this->getContainer()->get($id);
+                $instance = $this->container->get($id);
                 if (!isset($types[$instance->getExtendedType()])) {
                     $types[$instance->getExtendedType()] = [];
                 }

--- a/src/CoreBundle/Resources/config/commands.xml
+++ b/src/CoreBundle/Resources/config/commands.xml
@@ -3,9 +3,11 @@
     <services>
         <service id="Sonata\CoreBundle\Command\SonataDumpDoctrineMetaCommand" class="Sonata\CoreBundle\Command\SonataDumpDoctrineMetaCommand">
             <tag name="console.command"/>
+            <argument type="service" id="doctrine"/>
         </service>
         <service id="Sonata\CoreBundle\Command\SonataListFormMappingCommand" class="Sonata\CoreBundle\Command\SonataListFormMappingCommand">
             <tag name="console.command"/>
+            <argument type="service" id="service_container"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
## Subject

In preparation for SF 5.0 support the usage of ContainerAwareCommand must be removed.

For SonataListFormMappingCommand I've replaced it with a constructor that receives the container. I know this is not the way to use dependency injection, but in this case I think this is justified because it is simplest and the command is not usable in practice.

I am targeting this branch, because is is backwards compatible.

Closes #731

## Changelog

```markdown
### Fixed
- Replaced use of deprecated ContainerAwareCommand with Command.
```
