### PR TITLE
Remove DatagridBundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require": {
         "php": "^7.2",
         "cocur/slugify": "^1.4 || ^2.0 || ^3.0 || ^4.0",
-        "sonata-project/datagrid-bundle": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.1",
         "symfony/config": "^4.3",
         "symfony/dependency-injection": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2",
         "cocur/slugify": "^1.4 || ^2.0 || ^3.0 || ^4.0",
-        "sonata-project/datagrid-bundle": "^2.0",
+        "sonata-project/datagrid-bundle": "^2.0 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.1",
         "symfony/config": "^4.3",
         "symfony/dependency-injection": "^4.3",


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

The coreBundle does not use a lot the datagrid bundle but it's require in the `composer.json`.

I would like to require the datagridBundle 3.x in the adminBundle, in order to deprecate the Datagrid directory in favor of classes in the datagridBundle. But the adminBundle actually require the coreBundle which require the datagridBundle 2.x.

## Changelog

```markdown
### Remove
- Remove SonataDatagridBundle dependency
```