### PR TITLE
Fixed deprecation message for InlineConstraint always displayed

### DIFF
--- a/src/CoreBundle/Validator/Constraints/InlineConstraint.php
+++ b/src/CoreBundle/Validator/Constraints/InlineConstraint.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\CoreBundle\Validator\Constraints;
 
-if (!class_exists(Sonata\Form\Validator\Constraints\InlineConstraint::class, false)) {
+if (!class_exists(\Sonata\Form\Validator\Constraints\InlineConstraint::class, false)) {
     @trigger_error(
         'The '.__NAMESPACE__.'\InlineConstraint class is deprecated since version 3.13.0 and will be removed in 4.0.'
         .' Use Sonata\Form\Validator\Constraint\InlineConstraint instead.',


### PR DESCRIPTION
## Subject

I noticed that the following deprecation message was displayed all the time, even when the deprecated class wasn't called:

>  User Deprecated: The Sonata\CoreBundle\Validator\Constraints\InlineConstraint class is deprecated since version 3.13.0 and will be removed in 4.0. Use Sonata\Form\Validator\Constraint\InlineConstraint instead.

The reason is a small omission in the code. The following line:

```php
if (!class_exists(Sonata\Form\Validator\Constraints\InlineConstraint::class, false)) {
```

should have been:

```php
if (!class_exists(\Sonata\Form\Validator\Constraints\InlineConstraint::class, false)) {
```

The InlineConstraint class is the only class with this bug, all the other deprecated classes work correctly in this respect.

I am targeting this branch, because it's a backwards compatible change.

## Changelog

```markdown
### Fixed
- Deprecation message for InlineConstraint was always displayed
```
